### PR TITLE
Add Logos/Links to all brand in footer of all sites except CEN

### DIFF
--- a/packages/shared/components/document.marko
+++ b/packages/shared/components/document.marko
@@ -51,6 +51,6 @@ $ const siteContext = {
   </@above-container>
   <@below-container>
     <${input.belowContainer} />
-    <default-theme-site-footer />
+    <shared-site-footer />
   </@below-container>
 </marko-web-document>

--- a/packages/shared/components/marko.json
+++ b/packages/shared/components/marko.json
@@ -37,5 +37,8 @@
     "@aliases": "array",
     "@nodes": "array",
     "@config": "object"
+  },
+  "<shared-site-footer>": {
+    "template": "./site-footer.marko"
   }
 }

--- a/packages/shared/components/site-footer.marko
+++ b/packages/shared/components/site-footer.marko
@@ -1,0 +1,66 @@
+$ const { config, site } = out.global;
+
+$ const footerLogos = site.get("logos.footerMulti");
+
+$ const blockName = input.blockName || "site-footer";
+
+<marko-web-block
+  name=blockName
+  tag=(input.tag || "footer")
+  class=input.class
+  modifiers=input.modifiers
+  attrs=input.attrs
+>
+
+  <if(footerLogos)>
+    <default-theme-site-footer-container block-name=blockName modifiers=["secondary", "multi"]>
+      <div class="row">
+        <for|logo| of=footerLogos>
+          <div class="col-3 site-footer-logo">
+              <marko-web-img
+                class="img-fluid"
+                alt=logo.alt
+                src=logo.src
+                srcset=logo.srcset
+                link= {
+                  href: logo.href,
+                  title: logo.alt,
+                  target: "_blank",
+                }
+              />
+          </div>
+        </for>
+      </div>
+    </default-theme-site-footer-container>
+  </if>
+  <else>
+    <default-theme-site-footer-container block-name=blockName modifiers=["secondary"]>
+      <default-theme-site-navbar-brand block-name=blockName title=`${config.website("name")} Homepage`>
+        <default-theme-site-navbar-logo
+          block-name=blockName
+          alt=config.website("name")
+          src=site.get("logos.footer.src")
+          srcset=site.getAsArray("logos.footer.srcset").join(",")
+          lazyload=true
+        />
+      </default-theme-site-navbar-brand>
+    </default-theme-site-footer-container>
+  </else>
+  <default-theme-site-footer-container block-name=blockName modifiers=["primary"]>
+    <default-theme-site-footer-social-icons
+      block-name=blockName
+      items=site.getAsArray('socialMediaLinks')
+      icon-modifiers=["light", "xl", "shadow"]
+    />
+    <default-theme-site-navbar-items
+      block-name=blockName
+      items=site.getAsArray("navigation.footer.items")
+      reg-enabled=input.regEnabled
+      has-user=input.hasUser
+    />
+    <default-theme-site-footer-copyright
+      company=site.get("company")
+      notice=site.get("copyrightNotice")
+    />
+  </default-theme-site-footer-container>
+</marko-web-block>

--- a/packages/shared/components/site-footer.marko
+++ b/packages/shared/components/site-footer.marko
@@ -1,7 +1,5 @@
 $ const { config, site } = out.global;
-
-$ const footerLogos = site.get("logos.footerMulti");
-
+$ const brandLogos = site.getAsArray("logos.footer.brandLogos");
 $ const blockName = input.blockName || "site-footer";
 
 <marko-web-block
@@ -12,10 +10,10 @@ $ const blockName = input.blockName || "site-footer";
   attrs=input.attrs
 >
 
-  <if(footerLogos)>
-    <default-theme-site-footer-container block-name=blockName modifiers=["secondary", "multi"]>
-      <div class="row">
-        <for|logo| of=footerLogos>
+  <if(brandLogos.length)>
+    <default-theme-site-footer-container block-name=blockName modifiers=["secondary"]>
+      <div class="row brand-logos">
+        <for|logo| of=brandLogos>
           <div class="col-3 site-footer-logo">
               <marko-web-img
                 class="img-fluid"

--- a/packages/shared/components/site-footer.marko
+++ b/packages/shared/components/site-footer.marko
@@ -14,7 +14,7 @@ $ const blockName = input.blockName || "site-footer";
     <default-theme-site-footer-container block-name=blockName modifiers=["secondary"]>
       <div class="row brand-logos">
         <for|logo| of=brandLogos>
-          <div class="col-3 site-footer-logo">
+          <div class="col-3 col-sm site-footer-logo">
               <marko-web-img
                 class="img-fluid"
                 alt=logo.alt

--- a/packages/shared/config/footer-brand-logos.js
+++ b/packages/shared/config/footer-brand-logos.js
@@ -1,5 +1,5 @@
 module.exports = {
-  footerLogos: [
+  brandLogos: [
     {
       href: 'https://www.designdevelopmenttoday.com',
       alt: 'Visit Design & Development Today',

--- a/packages/shared/config/footer-logos.js
+++ b/packages/shared/config/footer-logos.js
@@ -1,0 +1,60 @@
+module.exports = {
+  footerLogos: [
+    {
+      href: 'https://www.designdevelopmenttoday.com',
+      alt: 'Visit Design & Development Today',
+      src: 'https://img.designdevelopmenttoday.com/files/base/indm/all/ddt_logo.png?h=60',
+      srcset: [
+        'https://img.designdevelopmenttoday.com/files/base/indm/all/ddt_logo.png?h=120 2x',
+      ],
+    },
+    {
+      href: 'https://www.foodmanufacturing.com',
+      alt: 'Visit Food Manufacturing',
+      src: 'https://img.foodmanufacturing.com/files/base/indm/all/fm_logo.png?h=60',
+      srcset: [
+        'https://img.foodmanufacturing.com/files/base/indm/all/fm_logo.png?h=120 2x',
+      ],
+    },
+    {
+      href: 'https://www.ien.com',
+      alt: 'Visit Industrial Equipment News (IEN)',
+      src: 'https://img.ien.com/files/base/indm/all/ien_logo.png?h=60',
+      srcset: [
+        'https://img.ien.com/files/base/indm/all/ien_logo.png?h=120 2x',
+      ],
+    },
+    {
+      href: 'https://www.impomag.com',
+      alt: 'Visit IMPO',
+      src: 'https://img.impomag.com/files/base/indm/all/impo_logo.png?h=60',
+      srcset: [
+        'https://img.impomag.com/files/base/indm/all/impo_logo.png?h=120 2x',
+      ],
+    },
+    {
+      href: 'https://www.inddist.com',
+      alt: 'Visit Industrial Distribution',
+      src: 'https://img.inddist.com/files/base/indm/id/static/id_logo.png?h=60',
+      srcset: [
+        'https://img.inddist.com/files/base/indm/id/static/id_logo.png?h=120 2x',
+      ],
+    },
+    {
+      href: 'https://www.manufacturing.net',
+      alt: 'Visit Manufacturing.net',
+      src: 'https://img.manufacturing.net/files/base/indm/all/mnet_logo.svg?h=60',
+      srcset: [
+        'https://img.manufacturing.net/files/base/indm/all/mnet_logo.svg?h=120 2x',
+      ],
+    },
+    {
+      href: 'https://www.mbtmag.com',
+      alt: 'Visit Manufacturing Business Technology',
+      src: 'https://img.mbtmag.com/files/base/indm/all/mbt_logo.png?h=60',
+      srcset: [
+        'https://img.mbtmag.com/files/base/indm/all/mbt_logo.png?h=120 2x',
+      ],
+    },
+  ],
+};

--- a/packages/shared/scss/components/_footer.scss
+++ b/packages/shared/scss/components/_footer.scss
@@ -1,17 +1,20 @@
 .site-footer {
   &__container {
-    &--multi {
-      @include make-container();
-      @include media-breakpoint-up(xl, $grid-breakpoints) {
-        max-width: map-get($grid-breakpoints, xl);
+    &--secondary {
+      .brand-logos {
+        @include make-container();
+        @include media-breakpoint-up(xl, $grid-breakpoints) {
+          max-width: map-get($grid-breakpoints, xl);
+        }
+        padding-bottom: 0;
       }
-      padding-bottom: 0;
       .row {
         justify-content: center;
         align-items: center;
       }
       .site-footer-logo {
         margin-bottom: map-get($spacers, 3);
+        filter: drop-shadow($theme-site-footer-logo-box-shadow);
       }
     }
   }

--- a/packages/shared/scss/components/_footer.scss
+++ b/packages/shared/scss/components/_footer.scss
@@ -14,7 +14,6 @@
       }
       .site-footer-logo {
         margin-bottom: map-get($spacers, 3);
-        filter: drop-shadow($theme-site-footer-logo-box-shadow);
       }
     }
   }

--- a/packages/shared/scss/components/_footer.scss
+++ b/packages/shared/scss/components/_footer.scss
@@ -1,0 +1,18 @@
+.site-footer {
+  &__container {
+    &--multi {
+      @include make-container();
+      @include media-breakpoint-up(xl, $grid-breakpoints) {
+        max-width: map-get($grid-breakpoints, xl);
+      }
+      padding-bottom: 0;
+      .row {
+        justify-content: center;
+        align-items: center;
+      }
+      .site-footer-logo {
+        margin-bottom: map-get($spacers, 3);
+      }
+    }
+  }
+}

--- a/packages/shared/scss/components/_footer.scss
+++ b/packages/shared/scss/components/_footer.scss
@@ -4,7 +4,7 @@
       .brand-logos {
         @include make-container();
         @include media-breakpoint-up(xl, $grid-breakpoints) {
-          max-width: map-get($grid-breakpoints, xl);
+          max-width: map-get($grid-breakpoints, xl) - 100;
         }
         padding-bottom: 0;
       }

--- a/packages/shared/scss/core.scss
+++ b/packages/shared/scss/core.scss
@@ -17,6 +17,7 @@ $theme-related-content-border-color: #dee2e6;
 @import "./components/ad-container";
 @import "./components/content-page";
 @import "./components/flows";
+@import "./components/footer";
 @import "./components/identity-x";
 @import "./components/node-list";
 @import "./components/node";

--- a/sites/designdevelopmenttoday.com/config/site.js
+++ b/sites/designdevelopmenttoday.com/config/site.js
@@ -1,4 +1,4 @@
-const { footerLogos } = require('@industrial-media/package-shared/config/footer-logos');
+const { brandLogos } = require('@industrial-media/package-shared/config/footer-brand-logos');
 
 const navigation = require('./navigation');
 const gam = require('./gam');
@@ -20,12 +20,12 @@ module.exports = {
       ],
     },
     footer: {
+      brandLogos,
       src: 'https://img.designdevelopmenttoday.com/files/base/indm/all/ddt_logo.png?h=60',
       srcset: [
         'https://img.designdevelopmenttoday.com/files/base/indm/all/ddt_logo.png?h=120 2x',
       ],
     },
-    footerMulti: footerLogos,
   },
   identityX: {
     appId: '5e28a3dd58e67b229e55ae43',

--- a/sites/designdevelopmenttoday.com/config/site.js
+++ b/sites/designdevelopmenttoday.com/config/site.js
@@ -1,3 +1,5 @@
+const { footerLogos } = require('@industrial-media/package-shared/config/footer-logos');
+
 const navigation = require('./navigation');
 const gam = require('./gam');
 const nativeX = require('./native-x');
@@ -23,6 +25,7 @@ module.exports = {
         'https://img.designdevelopmenttoday.com/files/base/indm/all/ddt_logo.png?h=120 2x',
       ],
     },
+    footerMulti: footerLogos,
   },
   identityX: {
     appId: '5e28a3dd58e67b229e55ae43',

--- a/sites/foodmanufacturing.com/config/site.js
+++ b/sites/foodmanufacturing.com/config/site.js
@@ -1,3 +1,5 @@
+const { footerLogos } = require('@industrial-media/package-shared/config/footer-logos');
+
 const navigation = require('./navigation');
 const gam = require('./gam');
 const nativeX = require('./native-x');
@@ -22,6 +24,7 @@ module.exports = {
         'https://img.foodmanufacturing.com/files/base/indm/all/fm_logo.png?h=120 2x',
       ],
     },
+    footerMulti: footerLogos,
   },
   identityX: {
     appId: '5e28a3dd58e67b229e55ae43',

--- a/sites/foodmanufacturing.com/config/site.js
+++ b/sites/foodmanufacturing.com/config/site.js
@@ -1,4 +1,4 @@
-const { footerLogos } = require('@industrial-media/package-shared/config/footer-logos');
+const { brandLogos } = require('@industrial-media/package-shared/config/footer-brand-logos');
 
 const navigation = require('./navigation');
 const gam = require('./gam');
@@ -19,12 +19,12 @@ module.exports = {
       ],
     },
     footer: {
+      brandLogos,
       src: 'https://img.foodmanufacturing.com/files/base/indm/all/fm_logo.png?h=60',
       srcset: [
         'https://img.foodmanufacturing.com/files/base/indm/all/fm_logo.png?h=120 2x',
       ],
     },
-    footerMulti: footerLogos,
   },
   identityX: {
     appId: '5e28a3dd58e67b229e55ae43',

--- a/sites/ien.com/config/site.js
+++ b/sites/ien.com/config/site.js
@@ -1,4 +1,4 @@
-const { footerLogos } = require('@industrial-media/package-shared/config/footer-logos');
+const { brandLogos } = require('@industrial-media/package-shared/config/footer-brand-logos');
 
 const navigation = require('./navigation');
 const gam = require('./gam');
@@ -20,12 +20,12 @@ module.exports = {
       ],
     },
     footer: {
+      brandLogos,
       src: 'https://img.ien.com/files/base/indm/all/ien_logo.png?h=60',
       srcset: [
         'https://img.ien.com/files/base/indm/all/ien_logo.png?h=120 2x',
       ],
     },
-    footerMulti: footerLogos,
   },
   identityX: {
     appId: '5e28a3dd58e67b229e55ae43',

--- a/sites/ien.com/config/site.js
+++ b/sites/ien.com/config/site.js
@@ -1,3 +1,5 @@
+const { footerLogos } = require('@industrial-media/package-shared/config/footer-logos');
+
 const navigation = require('./navigation');
 const gam = require('./gam');
 const nativeX = require('./native-x');
@@ -23,6 +25,7 @@ module.exports = {
         'https://img.ien.com/files/base/indm/all/ien_logo.png?h=120 2x',
       ],
     },
+    footerMulti: footerLogos,
   },
   identityX: {
     appId: '5e28a3dd58e67b229e55ae43',

--- a/sites/impomag.com/config/site.js
+++ b/sites/impomag.com/config/site.js
@@ -1,4 +1,4 @@
-const { footerLogos } = require('@industrial-media/package-shared/config/footer-logos');
+const { brandLogos } = require('@industrial-media/package-shared/config/footer-brand-logos');
 
 const navigation = require('./navigation');
 const gam = require('./gam');
@@ -19,12 +19,12 @@ module.exports = {
       ],
     },
     footer: {
+      brandLogos,
       src: 'https://img.impomag.com/files/base/indm/all/impo_logo.png?h=60',
       srcset: [
         'https://img.impomag.com/files/base/indm/all/impo_logo.png?h=120 2x',
       ],
     },
-    footerMulti: footerLogos,
   },
   identityX: {
     appId: '5e28a3dd58e67b229e55ae43',

--- a/sites/impomag.com/config/site.js
+++ b/sites/impomag.com/config/site.js
@@ -1,3 +1,5 @@
+const { footerLogos } = require('@industrial-media/package-shared/config/footer-logos');
+
 const navigation = require('./navigation');
 const gam = require('./gam');
 const nativeX = require('./native-x');
@@ -22,6 +24,7 @@ module.exports = {
         'https://img.impomag.com/files/base/indm/all/impo_logo.png?h=120 2x',
       ],
     },
+    footerMulti: footerLogos,
   },
   identityX: {
     appId: '5e28a3dd58e67b229e55ae43',

--- a/sites/inddist.com/config/site.js
+++ b/sites/inddist.com/config/site.js
@@ -1,4 +1,4 @@
-const { footerLogos } = require('@industrial-media/package-shared/config/footer-logos');
+const { brandLogos } = require('@industrial-media/package-shared/config/footer-brand-logos');
 
 const navigation = require('./navigation');
 const gam = require('./gam');
@@ -19,12 +19,12 @@ module.exports = {
       ],
     },
     footer: {
+      brandLogos,
       src: 'https://img.inddist.com/files/base/indm/id/static/id_logo.png?h=60',
       srcset: [
         'https://img.inddist.com/files/base/indm/id/static/id_logo.png?h=120 2x',
       ],
     },
-    footerMulti: footerLogos,
   },
   identityX: {
     appId: '5e28a3dd58e67b229e55ae43',

--- a/sites/inddist.com/config/site.js
+++ b/sites/inddist.com/config/site.js
@@ -1,3 +1,5 @@
+const { footerLogos } = require('@industrial-media/package-shared/config/footer-logos');
+
 const navigation = require('./navigation');
 const gam = require('./gam');
 const nativeX = require('./native-x');
@@ -22,6 +24,7 @@ module.exports = {
         'https://img.inddist.com/files/base/indm/id/static/id_logo.png?h=120 2x',
       ],
     },
+    footerMulti: footerLogos,
   },
   identityX: {
     appId: '5e28a3dd58e67b229e55ae43',

--- a/sites/manufacturing.net/config/site.js
+++ b/sites/manufacturing.net/config/site.js
@@ -1,3 +1,5 @@
+const { footerLogos } = require('@industrial-media/package-shared/config/footer-logos');
+
 const navigation = require('./navigation');
 const gam = require('./gam');
 const nativeX = require('./native-x');
@@ -22,6 +24,7 @@ module.exports = {
         'https://img.manufacturing.net/files/base/indm/all/mnet_logo.svg?h=120 2x',
       ],
     },
+    footerMulti: footerLogos,
   },
   identityX: {
     appId: '5e28a3dd58e67b229e55ae43',

--- a/sites/manufacturing.net/config/site.js
+++ b/sites/manufacturing.net/config/site.js
@@ -1,4 +1,4 @@
-const { footerLogos } = require('@industrial-media/package-shared/config/footer-logos');
+const { brandLogos } = require('@industrial-media/package-shared/config/footer-brand-logos');
 
 const navigation = require('./navigation');
 const gam = require('./gam');
@@ -19,12 +19,12 @@ module.exports = {
       ],
     },
     footer: {
+      brandLogos,
       src: 'https://img.manufacturing.net/files/base/indm/all/mnet_logo.svg?h=60',
       srcset: [
         'https://img.manufacturing.net/files/base/indm/all/mnet_logo.svg?h=120 2x',
       ],
     },
-    footerMulti: footerLogos,
   },
   identityX: {
     appId: '5e28a3dd58e67b229e55ae43',

--- a/sites/mbtmag.com/config/site.js
+++ b/sites/mbtmag.com/config/site.js
@@ -1,4 +1,4 @@
-const { footerLogos } = require('@industrial-media/package-shared/config/footer-logos');
+const { brandLogos } = require('@industrial-media/package-shared/config/footer-brand-logos');
 
 const navigation = require('./navigation');
 const gam = require('./gam');
@@ -19,12 +19,12 @@ module.exports = {
       ],
     },
     footer: {
+      brandLogos,
       src: 'https://img.mbtmag.com/files/base/indm/all/mbt_logo.png?h=60',
       srcset: [
         'https://img.mbtmag.com/files/base/indm/all/mbt_logo.png?h=120 2x',
       ],
     },
-    footerMulti: footerLogos,
   },
   identityX: {
     appId: '5e28a3dd58e67b229e55ae43',

--- a/sites/mbtmag.com/config/site.js
+++ b/sites/mbtmag.com/config/site.js
@@ -1,3 +1,5 @@
+const { footerLogos } = require('@industrial-media/package-shared/config/footer-logos');
+
 const navigation = require('./navigation');
 const gam = require('./gam');
 const nativeX = require('./native-x');
@@ -22,6 +24,7 @@ module.exports = {
         'https://img.mbtmag.com/files/base/indm/all/mbt_logo.png?h=120 2x',
       ],
     },
+    footerMulti: footerLogos,
   },
   identityX: {
     appId: '5e28a3dd58e67b229e55ae43',


### PR DESCRIPTION
Add shared footer-logos.js config to shared theme.  This is an array of logo objects.

**Example:**
```javascript
{
  href: 'https://www.foodmanufacturing.com',
  alt: 'Visit Food Manufacturing',
  src: 'https://img.foodmanufacturing.com/files/base/indm/all/fm_logo.png?h=60',
  srcset: [
    'https://img.foodmanufacturing.com/files/base/indm/all/fm_logo.png?h=120 2x',
  ],
},
```


This is then pulled in and set on the individual site config under the logos.footer.brandLogos.  Added logic to site footer, so if brandLogos has logo objects in it, to loop over the array and it will display the logo and link to the other brands. Instead of just displaying the footer logo.

<img width="1247" alt="Screen Shot 2021-03-24 at 12 04 32 PM" src="https://user-images.githubusercontent.com/3845869/112352951-3dd22800-8c99-11eb-9131-6429dfec155e.png">
<img width="616" alt="Screen Shot 2021-03-24 at 12 04 48 PM" src="https://user-images.githubusercontent.com/3845869/112352964-40348200-8c99-11eb-9d5a-adbb327dbde3.png">
<img width="445" alt="Screen Shot 2021-03-24 at 12 05 04 PM" src="https://user-images.githubusercontent.com/3845869/112352966-40cd1880-8c99-11eb-8ad7-2498fe7cdbb0.png">

