### PR TITLE
Add P1 event tracking & omeda rapid identifier

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -25,6 +25,7 @@ x-env-defaults: &env
   SENDGRID_DEV_TO: developer@endeavorb2b.com
   YARN_CACHE_FOLDER: /.yarn-cache
   IDENTITYX_GRAPHQL_URI: ${IDENTITYX_GRAPHQL_URI-https://identity-x.parameter1.com/graphql}
+  IDENTITYX_API_TOKEN: ${IDENTITYX_API_TOKEN-(unset)}
 
 x-env-marketing-cloud-indm: &env-marketing-cloud-indm
   FUEL_API_CLIENT_ID: ${INDM_FUEL_API_CLIENT_ID}

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -26,6 +26,8 @@ x-env-defaults: &env
   YARN_CACHE_FOLDER: /.yarn-cache
   IDENTITYX_GRAPHQL_URI: ${IDENTITYX_GRAPHQL_URI-https://identity-x.parameter1.com/graphql}
   IDENTITYX_API_TOKEN: ${IDENTITYX_API_TOKEN-(unset)}
+  OMEDA_APP_ID: ${OMEDA_APP_ID-(unset)}
+  OMEDA_INPUT_ID: ${OMEDA_INPUT_ID-(unset)}
 
 x-env-marketing-cloud-indm: &env-marketing-cloud-indm
   FUEL_API_CLIENT_ID: ${INDM_FUEL_API_CLIENT_ID}

--- a/packages/shared/browser/index.js
+++ b/packages/shared/browser/index.js
@@ -8,7 +8,6 @@ import PhotoSwipe from '@parameter1/base-cms-marko-web-photoswipe/browser';
 import ContactUs from '@industrial-media/package-contact-us/browser';
 import IdentityX from '@parameter1/base-cms-marko-web-identity-x/browser';
 import P1Events from '@parameter1/base-cms-marko-web-p1-events/browser';
-import OmedaRapidIdentityX from '@parameter1/base-cms-marko-web-omeda-identity-x/browser/rapid-identify.vue';
 
 const NewsletterSignup = () => import(/* webpackChunkName: "shared-newsletter-signup" */ './newsletter-signup/index.vue');
 
@@ -25,13 +24,4 @@ export default (Browser) => {
   P1Events(Browser);
 
   Browser.register('SharedNewsletterSignup', NewsletterSignup);
-  Browser.register('OmedaRapidIdentityX', OmedaRapidIdentityX, {
-    on: {
-      'encrypted-id-found': (encryptedId) => {
-        if (encryptedId && window.p1events) {
-          window.p1events('setIdentity', `omeda.indm.customer*${encryptedId}~encrypted`);
-        }
-      },
-    },
-  });
 };

--- a/packages/shared/browser/index.js
+++ b/packages/shared/browser/index.js
@@ -8,6 +8,7 @@ import PhotoSwipe from '@parameter1/base-cms-marko-web-photoswipe/browser';
 import ContactUs from '@industrial-media/package-contact-us/browser';
 import IdentityX from '@parameter1/base-cms-marko-web-identity-x/browser';
 import P1Events from '@parameter1/base-cms-marko-web-p1-events/browser';
+import OmedaRapidIdentityX from '@parameter1/base-cms-marko-web-omeda-identity-x/browser/rapid-identify.vue';
 
 const NewsletterSignup = () => import(/* webpackChunkName: "shared-newsletter-signup" */ './newsletter-signup/index.vue');
 
@@ -24,4 +25,13 @@ export default (Browser) => {
   P1Events(Browser);
 
   Browser.register('SharedNewsletterSignup', NewsletterSignup);
+  Browser.register('OmedaRapidIdentityX', OmedaRapidIdentityX, {
+    on: {
+      'encrypted-id-found': (encryptedId) => {
+        if (encryptedId && window.p1events) {
+          window.p1events('setIdentity', `omeda.indm.customer*${encryptedId}~encrypted`);
+        }
+      },
+    },
+  });
 };

--- a/packages/shared/browser/index.js
+++ b/packages/shared/browser/index.js
@@ -5,9 +5,9 @@ import GCSE from '@parameter1/base-cms-marko-web-gcse/browser';
 import RevealAd from '@parameter1/base-cms-marko-web-reveal-ad/browser';
 import SocialSharing from '@parameter1/base-cms-marko-web-social-sharing/browser';
 import PhotoSwipe from '@parameter1/base-cms-marko-web-photoswipe/browser';
-import IdentityX from '@parameter1/base-cms-marko-web-identity-x/browser';
-
 import ContactUs from '@industrial-media/package-contact-us/browser';
+import IdentityX from '@parameter1/base-cms-marko-web-identity-x/browser';
+import P1Events from '@parameter1/base-cms-marko-web-p1-events/browser';
 
 const NewsletterSignup = () => import(/* webpackChunkName: "shared-newsletter-signup" */ './newsletter-signup/index.vue');
 
@@ -21,6 +21,7 @@ export default (Browser) => {
   PhotoSwipe(Browser);
   ContactUs(Browser);
   IdentityX(Browser);
+  P1Events(Browser);
 
   Browser.register('SharedNewsletterSignup', NewsletterSignup);
 };

--- a/packages/shared/browser/omeda-incd.js
+++ b/packages/shared/browser/omeda-incd.js
@@ -1,0 +1,13 @@
+const OmedaRapidIdentityX = () => import(/* webpackChunkName: "incd-omeda-rapid-idenity-x" */ '@parameter1/base-cms-marko-web-omeda-identity-x/browser/rapid-identify.vue');
+
+export default (Browser) => {
+  Browser.register('OmedaRapidIdentityX', OmedaRapidIdentityX, {
+    on: {
+      'encrypted-id-found': (encryptedId) => {
+        if (encryptedId && window.p1events) {
+          window.p1events('setIdentity', `omeda.incd.customer*${encryptedId}~encrypted`);
+        }
+      },
+    },
+  });
+};

--- a/packages/shared/browser/omeda-lynchm.js
+++ b/packages/shared/browser/omeda-lynchm.js
@@ -1,0 +1,13 @@
+const OmedaRapidIdentityX = () => import(/* webpackChunkName: "lynchm-omeda-rapid-idenity-x" */ '@parameter1/base-cms-marko-web-omeda-identity-x/browser/rapid-identify.vue');
+
+export default (Browser) => {
+  Browser.register('OmedaRapidIdentityX', OmedaRapidIdentityX, {
+    on: {
+      'encrypted-id-found': (encryptedId) => {
+        if (encryptedId && window.p1events) {
+          window.p1events('setIdentity', `omeda.lynchm.customer*${encryptedId}~encrypted`);
+        }
+      },
+    },
+  });
+};

--- a/packages/shared/components/document.marko
+++ b/packages/shared/components/document.marko
@@ -1,5 +1,4 @@
 import { get } from "@parameter1/base-cms-object-path";
-import omedaConfig from "../config/omeda";
 
 $ const {
   config,
@@ -8,6 +7,7 @@ $ const {
   GAM,
   nativeX,
   leads,
+  omedaConfig,
 } = out.global;
 
 $ const siteContext = {

--- a/packages/shared/components/document.marko
+++ b/packages/shared/components/document.marko
@@ -1,4 +1,5 @@
 import { get } from "@parameter1/base-cms-object-path";
+import omedaConfig from "../config/omeda";
 
 $ const {
   config,
@@ -98,5 +99,6 @@ $ const siteContext = {
   </@below-container>
   <@below-wrapper>
     <marko-web-deferred-script-loader-load />
+    <marko-web-browser-component name="OmedaRapidIdentityX" />
   </@below-wrapper>
 </marko-web-document>

--- a/packages/shared/components/document.marko
+++ b/packages/shared/components/document.marko
@@ -29,6 +29,14 @@ $ const siteContext = {
 
     <marko-web-deferred-script-loader-init />
 
+    <!-- init p1 website events -->
+    <marko-web-p1-events-init
+      on="load"
+      request-frame=true
+      target-tag="body"
+      identity-query-builder=`var id = query.oly_enc_id; if (id) { return 'omeda.${omedaConfig.brandKey}.customer*' + id + '~encoded'; };`;
+    />
+
     <marko-web-gam-init
       on="load"
       request-frame=true

--- a/packages/shared/components/document.marko
+++ b/packages/shared/components/document.marko
@@ -62,6 +62,14 @@ $ const siteContext = {
       target-tag="body"
     />
 
+    <!-- init omeda olytics -->
+    <marko-web-omeda-olytics-init
+      oid="885288e230da4bf9ae9626e64e9fbf46"
+      on="load"
+      request-frame=true
+      target-tag="body"
+    />
+
     <${input.head} />
 
     <marko-web-gtm-start />

--- a/packages/shared/components/layouts/website-section/default.marko
+++ b/packages/shared/components/layouts/website-section/default.marko
@@ -45,6 +45,7 @@ $ const promise = websiteSectionContentLoader(apollo, {
         <marko-web-resolve-page|{ data: section }| node=pageNode>
           $ const aliases = hierarchyAliases(section);
           <marko-web-gam-slots slots=adSlots({ aliases }) />
+          <marko-web-p1-events-track-website-section node=section />
         </marko-web-resolve-page>
         <if(input.inHead)>
           <${input.inHead} section-content=sectionContent />

--- a/packages/shared/config/incd-omeda.js
+++ b/packages/shared/config/incd-omeda.js
@@ -1,0 +1,9 @@
+module.exports = {
+  brandKey: 'incd',
+  appId: process.env.OMEDA_APP_ID,
+  inputId: process.env.OMEDA_INPUT_ID,
+  graphqlUri: 'https://graphql.omeda.parameter1.com/',
+  rapidIdentification: {
+    productId: 715,
+  },
+};

--- a/packages/shared/config/lynchm-omeda.js
+++ b/packages/shared/config/lynchm-omeda.js
@@ -1,9 +1,9 @@
 module.exports = {
-  brandKey: 'indm',
+  brandKey: 'lynchm',
   appId: process.env.OMEDA_APP_ID,
   inputId: process.env.OMEDA_INPUT_ID,
   graphqlUri: 'https://graphql.omeda.parameter1.com/',
   rapidIdentification: {
-    productId: 999, // #### need from omeda ####
+    productId: 716,
   },
 };

--- a/packages/shared/config/omeda.js
+++ b/packages/shared/config/omeda.js
@@ -1,0 +1,9 @@
+module.exports = {
+  brandKey: 'indm',
+  appId: process.env.OMEDA_APP_ID,
+  inputId: process.env.OMEDA_INPUT_ID,
+  graphqlUri: 'https://graphql.omeda.parameter1.com/',
+  rapidIdentification: {
+    productId: 999, // #### need from omeda ####
+  },
+};

--- a/packages/shared/package.json
+++ b/packages/shared/package.json
@@ -26,6 +26,7 @@
     "@parameter1/base-cms-marko-web-native-x": "^2.22.2",
     "@parameter1/base-cms-marko-web-p1-events": "^2.22.2",
     "@parameter1/base-cms-marko-web-omeda": "^2.22.2",
+    "@parameter1/base-cms-marko-web-omeda-identity-x": "^2.22.2",
     "@parameter1/base-cms-marko-web-photoswipe": "^2.22.2",
     "@parameter1/base-cms-marko-web-reveal-ad": "^2.22.2",
     "@parameter1/base-cms-marko-web-social-sharing": "^2.22.2",

--- a/packages/shared/package.json
+++ b/packages/shared/package.json
@@ -24,6 +24,8 @@
     "@parameter1/base-cms-marko-web-icons": "^2.0.0",
     "@parameter1/base-cms-marko-web-identity-x": "^2.22.2",
     "@parameter1/base-cms-marko-web-native-x": "^2.22.2",
+    "@parameter1/base-cms-marko-web-p1-events": "^2.22.2",
+    "@parameter1/base-cms-marko-web-omeda": "^2.22.2",
     "@parameter1/base-cms-marko-web-photoswipe": "^2.22.2",
     "@parameter1/base-cms-marko-web-reveal-ad": "^2.22.2",
     "@parameter1/base-cms-marko-web-social-sharing": "^2.22.2",

--- a/packages/shared/start-server.js
+++ b/packages/shared/start-server.js
@@ -45,6 +45,10 @@ module.exports = (options = {}) => {
       const gamConfig = get(options, 'siteConfig.gam');
       if (gamConfig) set(app.locals, 'GAM', gamConfig);
 
+      // Setup GAM.
+      const omedaConfig = get(options, 'siteConfig.omeda');
+      if (omedaConfig) set(app.locals, 'omedaConfig', omedaConfig);
+
       // Setup NativeX.
       set(app.locals, 'nativeX', buildNativeXConfig(nativeXConfig));
 

--- a/packages/shared/templates/content/index.marko
+++ b/packages/shared/templates/content/index.marko
@@ -37,6 +37,7 @@ $ const injectAds = ["article", "news", "press-release", "blog"].includes(type) 
     <marko-web-resolve-page|{ data: content }| node=pageNode>
       $ const aliases = hierarchyAliases(content.primarySection);
       <marko-web-gam-slots slots=adSlots({ aliases }) />
+      <marko-web-p1-events-track-content node=content />
     </marko-web-resolve-page>
   </@head>
   <@above-container>

--- a/packages/shared/templates/dynamic-page/index.marko
+++ b/packages/shared/templates/dynamic-page/index.marko
@@ -8,7 +8,10 @@ $ const { id, alias, pageNode } = data;
     </marko-web-gtm-dynamic-page-context>
   </@head>
   <@above-container>
-    <marko-web-gam-out-of-page-ad ...GAM.getAdUnit({ name: "reskin" }) />
+    <marko-web-resolve-page|{ data: page }| node=pageNode>
+      <marko-web-gam-out-of-page-ad ...GAM.getAdUnit({ name: "reskin" }) />
+      <marko-web-p1-events-track-content node=page />
+    </marko-web-resolve-page>
   </@above-container>
   <@page>
     <marko-web-resolve-page|{ data: page }| node=pageNode>

--- a/sites/cannabisequipmentnews.com/browser/index.js
+++ b/sites/cannabisequipmentnews.com/browser/index.js
@@ -1,6 +1,8 @@
 import Browser from '@parameter1/base-cms-marko-web/browser';
 import Shared from '@industrial-media/package-shared/browser';
+import Omeda from '@industrial-media/package-shared/browser/omeda-lynchm';
 
 Shared(Browser);
+Omeda(Browser);
 
 export default Browser;

--- a/sites/cannabisequipmentnews.com/config/site.js
+++ b/sites/cannabisequipmentnews.com/config/site.js
@@ -1,3 +1,5 @@
+const omeda = require('@industrial-media/package-shared/config/lynchm-omeda');
+
 const navigation = require('./navigation');
 const gam = require('./gam');
 const nativeX = require('./native-x');
@@ -6,6 +8,7 @@ const socialMediaLinks = require('./social-links');
 module.exports = {
   navigation,
   gam,
+  omeda,
   nativeX,
   socialMediaLinks,
   company: 'Lynch Media',

--- a/sites/cannabisequipmentnews.com/config/site.js
+++ b/sites/cannabisequipmentnews.com/config/site.js
@@ -9,6 +9,11 @@ module.exports = {
   nativeX,
   socialMediaLinks,
   company: 'Lynch Media',
+  p1events: {
+    tenant: 'indm',
+    enabled: true,
+    cookieDomain: process.env.NODE_ENV === 'production' ? 'cannabisequipmentnews.com' : '',
+  },
   simpleFavicon: true,
   logos: {
     navbar: {

--- a/sites/designdevelopmenttoday.com/browser/index.js
+++ b/sites/designdevelopmenttoday.com/browser/index.js
@@ -1,6 +1,8 @@
 import Browser from '@parameter1/base-cms-marko-web/browser';
 import Shared from '@industrial-media/package-shared/browser';
+import Omeda from '@industrial-media/package-shared/browser/omeda-incd';
 
 Shared(Browser);
+Omeda(Browser);
 
 export default Browser;

--- a/sites/designdevelopmenttoday.com/config/site.js
+++ b/sites/designdevelopmenttoday.com/config/site.js
@@ -1,4 +1,5 @@
 const { brandLogos } = require('@industrial-media/package-shared/config/footer-brand-logos');
+const omeda = require('@industrial-media/package-shared/config/incd-omeda');
 
 const navigation = require('./navigation');
 const gam = require('./gam');
@@ -8,6 +9,7 @@ const socialMediaLinks = require('./social-links');
 module.exports = {
   navigation,
   gam,
+  omeda,
   nativeX,
   socialMediaLinks,
   company: 'Industrial Media, LLC',

--- a/sites/designdevelopmenttoday.com/config/site.js
+++ b/sites/designdevelopmenttoday.com/config/site.js
@@ -11,6 +11,11 @@ module.exports = {
   nativeX,
   socialMediaLinks,
   company: 'Industrial Media, LLC',
+  p1events: {
+    tenant: 'indm',
+    enabled: true,
+    cookieDomain: process.env.NODE_ENV === 'production' ? 'designdevelopmenttoday.com' : '',
+  },
   simpleFavicon: true,
   logos: {
     navbar: {

--- a/sites/foodmanufacturing.com/browser/index.js
+++ b/sites/foodmanufacturing.com/browser/index.js
@@ -1,6 +1,8 @@
 import Browser from '@parameter1/base-cms-marko-web/browser';
 import Shared from '@industrial-media/package-shared/browser';
+import Omeda from '@industrial-media/package-shared/browser/omeda-incd';
 
 Shared(Browser);
+Omeda(Browser);
 
 export default Browser;

--- a/sites/foodmanufacturing.com/config/site.js
+++ b/sites/foodmanufacturing.com/config/site.js
@@ -1,4 +1,5 @@
 const { brandLogos } = require('@industrial-media/package-shared/config/footer-brand-logos');
+const omeda = require('@industrial-media/package-shared/config/incd-omeda');
 
 const navigation = require('./navigation');
 const gam = require('./gam');
@@ -8,6 +9,7 @@ const socialMediaLinks = require('./social-links');
 module.exports = {
   navigation,
   gam,
+  omeda,
   nativeX,
   socialMediaLinks,
   company: 'Industrial Media, LLC',

--- a/sites/foodmanufacturing.com/config/site.js
+++ b/sites/foodmanufacturing.com/config/site.js
@@ -11,6 +11,11 @@ module.exports = {
   nativeX,
   socialMediaLinks,
   company: 'Industrial Media, LLC',
+  p1events: {
+    tenant: 'indm',
+    enabled: true,
+    cookieDomain: process.env.NODE_ENV === 'production' ? 'foodmanufacturing.com' : '',
+  },
   logos: {
     navbar: {
       src: 'https://img.foodmanufacturing.com/files/base/indm/all/fm_logo.png?h=45',

--- a/sites/ien.com/browser/index.js
+++ b/sites/ien.com/browser/index.js
@@ -1,6 +1,8 @@
 import Browser from '@parameter1/base-cms-marko-web/browser';
 import Shared from '@industrial-media/package-shared/browser';
+import Omeda from '@industrial-media/package-shared/browser/omeda-incd';
 
 Shared(Browser);
+Omeda(Browser);
 
 export default Browser;

--- a/sites/ien.com/config/site.js
+++ b/sites/ien.com/config/site.js
@@ -1,4 +1,5 @@
 const { brandLogos } = require('@industrial-media/package-shared/config/footer-brand-logos');
+const omeda = require('@industrial-media/package-shared/config/incd-omeda');
 
 const navigation = require('./navigation');
 const gam = require('./gam');
@@ -8,6 +9,7 @@ const socialMediaLinks = require('./social-links');
 module.exports = {
   navigation,
   gam,
+  omeda,
   nativeX,
   socialMediaLinks,
   company: 'Industrial Media, LLC',

--- a/sites/ien.com/config/site.js
+++ b/sites/ien.com/config/site.js
@@ -11,6 +11,11 @@ module.exports = {
   nativeX,
   socialMediaLinks,
   company: 'Industrial Media, LLC',
+  p1events: {
+    tenant: 'indm',
+    enabled: true,
+    cookieDomain: process.env.NODE_ENV === 'production' ? 'ien.com' : '',
+  },
   simpleFavicon: true,
   logos: {
     navbar: {

--- a/sites/impomag.com/browser/index.js
+++ b/sites/impomag.com/browser/index.js
@@ -1,6 +1,8 @@
 import Browser from '@parameter1/base-cms-marko-web/browser';
 import Shared from '@industrial-media/package-shared/browser';
+import Omeda from '@industrial-media/package-shared/browser/omeda-incd';
 
 Shared(Browser);
+Omeda(Browser);
 
 export default Browser;

--- a/sites/impomag.com/config/site.js
+++ b/sites/impomag.com/config/site.js
@@ -1,4 +1,5 @@
 const { brandLogos } = require('@industrial-media/package-shared/config/footer-brand-logos');
+const omeda = require('@industrial-media/package-shared/config/incd-omeda');
 
 const navigation = require('./navigation');
 const gam = require('./gam');
@@ -8,6 +9,7 @@ const socialMediaLinks = require('./social-links');
 module.exports = {
   navigation,
   gam,
+  omeda,
   nativeX,
   socialMediaLinks,
   company: 'Industrial Media, LLC',

--- a/sites/impomag.com/config/site.js
+++ b/sites/impomag.com/config/site.js
@@ -11,6 +11,11 @@ module.exports = {
   nativeX,
   socialMediaLinks,
   company: 'Industrial Media, LLC',
+  p1events: {
+    tenant: 'indm',
+    enabled: true,
+    cookieDomain: process.env.NODE_ENV === 'production' ? 'impomag.com' : '',
+  },
   logos: {
     navbar: {
       src: 'https://img.impomag.com/files/base/indm/all/impo_logo.png?h=45',

--- a/sites/inddist.com/browser/index.js
+++ b/sites/inddist.com/browser/index.js
@@ -1,6 +1,8 @@
 import Browser from '@parameter1/base-cms-marko-web/browser';
 import Shared from '@industrial-media/package-shared/browser';
+import Omeda from '@industrial-media/package-shared/browser/omeda-incd';
 
 Shared(Browser);
+Omeda(Browser);
 
 export default Browser;

--- a/sites/inddist.com/config/site.js
+++ b/sites/inddist.com/config/site.js
@@ -1,4 +1,5 @@
 const { brandLogos } = require('@industrial-media/package-shared/config/footer-brand-logos');
+const omeda = require('@industrial-media/package-shared/config/incd-omeda');
 
 const navigation = require('./navigation');
 const gam = require('./gam');
@@ -8,6 +9,7 @@ const socialMediaLinks = require('./social-links');
 module.exports = {
   navigation,
   gam,
+  omeda,
   nativeX,
   socialMediaLinks,
   company: 'Industrial Media, LLC',

--- a/sites/inddist.com/config/site.js
+++ b/sites/inddist.com/config/site.js
@@ -11,6 +11,11 @@ module.exports = {
   nativeX,
   socialMediaLinks,
   company: 'Industrial Media, LLC',
+  p1events: {
+    tenant: 'indm',
+    enabled: true,
+    cookieDomain: process.env.NODE_ENV === 'production' ? 'inddist.com' : '',
+  },
   logos: {
     navbar: {
       src: 'https://img.inddist.com/files/base/indm/id/static/id_logo.png?h=45',

--- a/sites/manufacturing.net/browser/index.js
+++ b/sites/manufacturing.net/browser/index.js
@@ -1,6 +1,8 @@
 import Browser from '@parameter1/base-cms-marko-web/browser';
 import Shared from '@industrial-media/package-shared/browser';
+import Omeda from '@industrial-media/package-shared/browser/omeda-incd';
 
 Shared(Browser);
+Omeda(Browser);
 
 export default Browser;

--- a/sites/manufacturing.net/config/site.js
+++ b/sites/manufacturing.net/config/site.js
@@ -1,4 +1,5 @@
 const { brandLogos } = require('@industrial-media/package-shared/config/footer-brand-logos');
+const omeda = require('@industrial-media/package-shared/config/incd-omeda');
 
 const navigation = require('./navigation');
 const gam = require('./gam');
@@ -8,6 +9,7 @@ const socialMediaLinks = require('./social-links');
 module.exports = {
   navigation,
   gam,
+  omeda,
   nativeX,
   socialMediaLinks,
   company: 'Industrial Media, LLC',

--- a/sites/manufacturing.net/config/site.js
+++ b/sites/manufacturing.net/config/site.js
@@ -11,6 +11,11 @@ module.exports = {
   nativeX,
   socialMediaLinks,
   company: 'Industrial Media, LLC',
+  p1events: {
+    tenant: 'indm',
+    enabled: true,
+    cookieDomain: process.env.NODE_ENV === 'production' ? 'manufacturing.net' : '',
+  },
   logos: {
     navbar: {
       src: 'https://img.manufacturing.net/files/base/indm/all/mnet_logo.svg?h=45',

--- a/sites/mbtmag.com/browser/index.js
+++ b/sites/mbtmag.com/browser/index.js
@@ -1,6 +1,8 @@
 import Browser from '@parameter1/base-cms-marko-web/browser';
 import Shared from '@industrial-media/package-shared/browser';
+import Omeda from '@industrial-media/package-shared/browser/omeda-incd';
 
 Shared(Browser);
+Omeda(Browser);
 
 export default Browser;

--- a/sites/mbtmag.com/config/site.js
+++ b/sites/mbtmag.com/config/site.js
@@ -11,6 +11,11 @@ module.exports = {
   nativeX,
   socialMediaLinks,
   company: 'Industrial Media, LLC',
+  p1events: {
+    tenant: 'indm',
+    enabled: true,
+    cookieDomain: process.env.NODE_ENV === 'production' ? 'mbtmag.com' : '',
+  },
   logos: {
     navbar: {
       src: 'https://img.mbtmag.com/files/base/indm/all/mbt_logo.png?h=45',

--- a/sites/mbtmag.com/config/site.js
+++ b/sites/mbtmag.com/config/site.js
@@ -1,4 +1,5 @@
 const { brandLogos } = require('@industrial-media/package-shared/config/footer-brand-logos');
+const omeda = require('@industrial-media/package-shared/config/incd-omeda');
 
 const navigation = require('./navigation');
 const gam = require('./gam');
@@ -8,6 +9,7 @@ const socialMediaLinks = require('./social-links');
 module.exports = {
   navigation,
   gam,
+  omeda,
   nativeX,
   socialMediaLinks,
   company: 'Industrial Media, LLC',

--- a/yarn.lock
+++ b/yarn.lock
@@ -2219,6 +2219,16 @@
     graphql-tag "^2.11.0"
     node-fetch "^2.6.1"
 
+"@parameter1/base-cms-marko-web-omeda-identity-x@^2.22.2":
+  version "2.22.2"
+  resolved "https://registry.yarnpkg.com/@parameter1/base-cms-marko-web-omeda-identity-x/-/base-cms-marko-web-omeda-identity-x-2.22.2.tgz#f6aec110725a5ad22c87124927e280be223dd7d7"
+  integrity sha512-Y7H1wjxoQZGDDjTr59uCp4eoyc5DOZvAIEy1QyhPxgiGDAB08cgPH4y5+d1r34p+yKGr5OMZGs/XDag6e2Winw==
+  dependencies:
+    "@parameter1/base-cms-object-path" "^2.22.2"
+    "@parameter1/base-cms-utils" "^2.22.2"
+    graphql "^14.7.0"
+    graphql-tag "^2.11.0"
+
 "@parameter1/base-cms-marko-web-omeda@^2.22.2":
   version "2.22.2"
   resolved "https://registry.yarnpkg.com/@parameter1/base-cms-marko-web-omeda/-/base-cms-marko-web-omeda-2.22.2.tgz#03379580e4db9a2ff19f783533f8d7f25291cabc"

--- a/yarn.lock
+++ b/yarn.lock
@@ -2219,6 +2219,22 @@
     graphql-tag "^2.11.0"
     node-fetch "^2.6.1"
 
+"@parameter1/base-cms-marko-web-omeda@^2.22.2":
+  version "2.22.2"
+  resolved "https://registry.yarnpkg.com/@parameter1/base-cms-marko-web-omeda/-/base-cms-marko-web-omeda-2.22.2.tgz#03379580e4db9a2ff19f783533f8d7f25291cabc"
+  integrity sha512-aYwFqk2I4gc4XvcJicc4GEOGAtcLCkgOMWvdYycIwPeWUS7pVga3bCuZtcoyQOlOfv1Td7FXuS4dmeN2Vtcc0Q==
+  dependencies:
+    "@parameter1/base-cms-marko-web-deferred-script-loader" "^2.22.2"
+
+"@parameter1/base-cms-marko-web-p1-events@^2.22.2":
+  version "2.22.2"
+  resolved "https://registry.yarnpkg.com/@parameter1/base-cms-marko-web-p1-events/-/base-cms-marko-web-p1-events-2.22.2.tgz#53c8c2ded54d932b7799fe523ddd181778d9e1bb"
+  integrity sha512-MKDZAlxHvLTWs3ntzD073sHkKE1NUClM0ooTEBdLkCnxXbkDwfiRJDls8iWxtK/XZuDoGHqitVDppo0E9F5pig==
+  dependencies:
+    "@parameter1/base-cms-inflector" "^2.0.0"
+    "@parameter1/base-cms-marko-web-deferred-script-loader" "^2.22.2"
+    "@parameter1/base-cms-object-path" "^2.22.2"
+
 "@parameter1/base-cms-marko-web-photoswipe@^2.22.2":
   version "2.22.2"
   resolved "https://registry.yarnpkg.com/@parameter1/base-cms-marko-web-photoswipe/-/base-cms-marko-web-photoswipe-2.22.2.tgz#c07f0b10f5927896fc11e7d6672849a2db892759"


### PR DESCRIPTION
 - Add deferred script loading for P1events & olytics (**@todo: update gtm tag for defered script loading of olytics**)
 - Set omedaConfig to global from siteConfig to allow for brandIds & productIds
 - Setup a lynchm & incd version of the rapidIdentiry vue component per brand and include on the site based on which brand they belong to.

### CEN
<img width="849" alt="Screen Shot 2021-06-02 at 12 42 40 PM" src="https://user-images.githubusercontent.com/3845869/120528281-e3dc9580-c3a0-11eb-9fec-33eed44adadf.png">

### IEN
<img width="801" alt="Screen Shot 2021-06-02 at 12 48 06 PM" src="https://user-images.githubusercontent.com/3845869/120528286-e5a65900-c3a0-11eb-892d-4d0bb2e46519.png">
