### PR TITLE
Update node versions to 10.24

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -11,7 +11,7 @@ RUN yarn --production --pure-lockfile
 WORKDIR /root/sites/$SITE
 RUN node_modules/.bin/basecms-website build
 
-FROM node:10.15-alpine
+FROM node:10.24-alpine
 ENV NODE_ENV production
 ENV PORT 80
 ARG SITE

--- a/services/marketing-cloud/Dockerfile
+++ b/services/marketing-cloud/Dockerfile
@@ -1,4 +1,4 @@
-FROM node:10.15 as build
+FROM node:10.24 as build
 WORKDIR /root
 ENV NODE_ENV production
 ARG SERVICE
@@ -10,7 +10,7 @@ RUN yarn --production --pure-lockfile
 
 WORKDIR /root/services/$SERVICE
 
-FROM node:10.15-alpine
+FROM node:10.24-alpine
 ENV NODE_ENV production
 ARG SERVICE
 COPY --from=build /root /root


### PR DESCRIPTION
Updates 10.15 versions that were missed in #129. Fixes build errors due to version mismatch for marketing cloud service