### PR TITLE
Server-side Leads identity cookie handling + video tracking

### DIFF
--- a/packages/shared/components/document.marko
+++ b/packages/shared/components/document.marko
@@ -6,6 +6,7 @@ $ const {
   req,
   GAM,
   nativeX,
+  leads,
 } = out.global;
 
 $ const siteContext = {
@@ -59,7 +60,8 @@ $ const siteContext = {
     <marko-web-gam-enable />
     $ const keyValues = {
       uri: req.path,
-      ...(req.cookies["et-usr"] && { et_usr: req.cookies["et-usr"] }),
+      ...(leads.identity.id && { leads_idt: leads.identity.id }),
+      ...(leads.identity.legacyId && { et_usr: leads.identity.legacyId }),
     };
     <marko-web-gam-targeting key-values=keyValues />
   </@head>

--- a/packages/shared/components/elements/embed-code.marko
+++ b/packages/shared/components/elements/embed-code.marko
@@ -1,38 +1,22 @@
 import cheerio from "cheerio";
 
+$ const { identity } = out.global.leads;
 $ const { content, blockName } = input;
+
+$ const identityParams = encodeURIComponent(Object.keys(identity).reduce((arr, key) => {
+  const v = identity[key];
+  if (!v) return arr;
+  const k = key === 'id' ? 'leads_idt' : 'et_usr';
+  arr.push(`${k}=${v}`);
+  return arr;
+}, []).join('&'));
 
 $ const $ = cheerio.load(content.embedCode);
 $ const scripts = $('script[src*="players.brightcove.net"]');
 
 <if(content.embedCode)>
   <marko-web-content-embed-code block-name=blockName obj=content />
-  <if(scripts.length)>
-    <script>
-      var players = videojs.getAllPlayers();
-      for (var i = 0; i < players.length; i += 1) {
-        players[i].ready(function() {
-          const player = this;
-          if (!player.ima3) return;
-          player.ima3.adMacroReplacement = function(url) {
-            if (!url || !document.cookie) return url;
-            var cookie = document.cookie.split(';').map(function(item) {
-              var parts = item.split('=');
-              return { key: parts[0].trim(), value: parts[1].trim() }
-            }).find(function(cookie) {
-              return cookie.key === 'et-usr';
-            });
-            if (!cookie) return url;
-
-            var el = document.createElement('a');
-            el.href = url;
-            var customParams = 'cust_params=et_usr%3D' + cookie.value;
-            console.log('VIDEOJS: Setting custom params', customParams);
-            el.search = el.search ? el.search + '&' + customParams : '?' + customParams;
-            return el.href;
-          };
-        });
-      }
-    </script>
+  <if(scripts.length && identityParams)>
+    <script>var players = videojs.getAllPlayers(); for (var i = 0; i < players.length; i += 1) { players[i].ready(function() { var player = this; if (!player.ima3) return; player.ima3.adMacroReplacement = function(url) { if (!url) return url; var el = document.createElement('a'); el.href = url; console.log('VIDEOJS: Setting custom params', '${identityParams}'); el.search = el.search ? el.search + '&' + 'cust_params=${identityParams}' : '?' + 'cust_params=${identityParams}'; return el.href; }; }); }</script>
   </if>
 </if>

--- a/packages/shared/middleware/leads.js
+++ b/packages/shared/middleware/leads.js
@@ -1,0 +1,43 @@
+const isOmedaId = value => /^[a-z0-9]{15}$/i.test(value);
+const isExactTargetId = value => /^[0-9]+$/.test(value);
+
+const extractOmedaId = (query, name) => {
+  const usr = query[name];
+  if (!usr) return null;
+  return isOmedaId(usr) ? usr : null;
+};
+
+const extractExactTargetId = (query, name) => {
+  const usr = query[name];
+  if (!usr) return null;
+  if (isOmedaId(usr)) return null;
+  return isExactTargetId(usr) ? usr : null;
+};
+
+const setCookie = (res, name, value) => {
+  res.cookie(name, value, { maxAge: 365 * 24 * 60 * 60 * 1000 });
+};
+
+module.exports = ({
+  queryParamName = 'lt.usr',
+  cookieName = 'leads-idt',
+  legacyCookieName = 'et-usr',
+} = {}) => (req, res, next) => {
+  const { cookies, query } = req;
+  const identity = {
+    id: cookies[cookieName] || null,
+    legacyId: cookies[legacyCookieName] || null,
+  };
+  const omedaId = extractOmedaId(query, queryParamName);
+  const exactTargetId = extractExactTargetId(query, queryParamName);
+  if (omedaId) {
+    setCookie(res, cookieName, omedaId);
+    identity.id = omedaId;
+  }
+  if (exactTargetId) {
+    setCookie(res, legacyCookieName, exactTargetId);
+    identity.legacyId = exactTargetId;
+  }
+  res.locals.leads = { identity };
+  next();
+};

--- a/packages/shared/start-server.js
+++ b/packages/shared/start-server.js
@@ -13,6 +13,7 @@ const components = require('./components');
 const fragments = require('./fragments');
 const userRoutes = require('./routes/user');
 const newsletterRoute = require('./routes/newsletter-signup');
+const leadsMiddleware = require('./middleware/leads');
 
 const routes = siteRoutes => (app) => {
   // Handle contact submissions on /__contact-us
@@ -46,6 +47,9 @@ module.exports = (options = {}) => {
 
       // Setup NativeX.
       set(app.locals, 'nativeX', buildNativeXConfig(nativeXConfig));
+
+      // Use lead management middleware
+      app.use(leadsMiddleware());
 
       // Use paginated middleware
       app.use(htmlSitemapPagination());


### PR DESCRIPTION
Parses Leads identities and sets cookies server-side. Additionally, when present, pass the identifiers to Brightcove.