### PR TITLE
Ensure company name header is URL safe

### DIFF
--- a/packages/shared/leads-content-handler.js
+++ b/packages/shared/leads-content-handler.js
@@ -16,7 +16,8 @@ module.exports = {
     if (node.taxonomyIds.includes(3193399) || node.type === 'product') tags.add('PR');
     if (node.type === 'video') tags.add('Video');
     if (node.company && node.company.name) {
-      res.set('x-lead-management-customer', node.company.name);
+      const companyName = encodeURIComponent(node.company.name);
+      res.set('x-lead-management-customer', companyName);
     }
     res.set('x-lead-management-link-type', 'Editorial');
     res.set('x-lead-management-tags', [...tags].join(', '));


### PR DESCRIPTION
Prevents error when attempting to send a non-url-safe value as part of a header value.