### PR TITLE
Add bc floating player

### DIFF
--- a/packages/shared/browser/floating-video-player.vue
+++ b/packages/shared/browser/floating-video-player.vue
@@ -1,0 +1,139 @@
+<template>
+  <div v-if="active" id="brightcove-floating-player" class="col-lg-4 col-sm-6 p-0">
+    <button
+      class="btn btn-secondary text-light"
+      type="button"
+      @click="close"
+    >
+      Close
+      <icon-x :modifiers="iconMods" />
+    </button>
+    <slot />
+  </div>
+</template>
+
+<script>
+import IconX from '@parameter1/base-cms-marko-web-icons/browser/x.vue';
+import brightcovePlayerLoader from '@brightcove/player-loader';
+
+export default {
+  components: {
+    IconX,
+  },
+  props: {
+    identityParams: {
+      type: String,
+      default: '',
+    },
+    enabled: {
+      type: Boolean,
+      default: false,
+    },
+    accountId: {
+      type: String,
+      required: true,
+    },
+    videoId: {
+      type: String,
+      default: null,
+    },
+    playlistId: {
+      type: String,
+      default: null,
+    },
+    playerId: {
+      type: String,
+      default: null,
+    },
+    embedId: {
+      type: String,
+      default: 'default',
+    },
+  },
+  data: () => ({
+    player: null,
+    open: true,
+    error: null,
+    iconMods: ['light'],
+  }),
+  computed: {
+    active() {
+      return this.enabled && this.open;
+    },
+  },
+  async mounted() {
+    if (this.enabled) {
+      try {
+        const { ref } = await brightcovePlayerLoader({
+          accountId: this.accountId,
+          playerId: this.playerId,
+          embedId: this.embedId,
+          videoId: this.videoId,
+          playlistId: this.playlistId,
+          refNode: this.$el,
+          embedOptions: {
+            responsive: {
+              maxWidth: '960px',
+            },
+          },
+        });
+        this.player = ref;
+
+        const { identityParams } = this;
+        this.player.ready(function setIdentityParams() {
+          const player = this;
+          if (!player.ima3) return;
+          player.ima3.adMacroReplacement = function leadManagementReplacer(url) {
+            if (!url) return url;
+            const addr = new URL(url);
+            addr.searchParams.set('cust_params', identityParams);
+            console.log('VIDEOJS: Setting custom params', `${identityParams}`);
+            return addr.toString();
+          };
+        });
+        this.open = true;
+      } catch (e) {
+        const { error } = console;
+        error(e);
+      }
+    }
+  },
+  methods: {
+    close() {
+      this.player.pause();
+      this.player.reset();
+      this.open = false;
+    },
+  },
+};
+</script>
+
+<style scoped>
+#brightcove-floating-player {
+  position: fixed;
+  right: 1rem;
+  bottom: 1rem;
+  width: 50%;
+  box-shadow: 5px 5px 15px 5px #000000;
+}
+
+#brightcove-floating-player .btn {
+  position: absolute;
+  right: 0;
+  top: -2.42rem;
+}
+
+@keyframes slide-top {
+  0% {
+    transform: translateY(0);
+  }
+  100% {
+    transform: translateY(calc(-90px - 1rem));
+  }
+}
+
+.marko-web-gam-fixed-ad-bottom.marko-web-gam-fixed-ad-bottom--visible
+~ #brightcove-floating-player {
+  animation: slide-top 0.5s cubic-bezier(0.250, 0.460, 0.450, 0.940) both;
+}
+</style>

--- a/packages/shared/browser/index.js
+++ b/packages/shared/browser/index.js
@@ -8,6 +8,7 @@ import PhotoSwipe from '@parameter1/base-cms-marko-web-photoswipe/browser';
 import ContactUs from '@industrial-media/package-contact-us/browser';
 import P1Events from '@parameter1/base-cms-marko-web-p1-events/browser';
 import OmedaIdentityX from '@parameter1/base-cms-marko-web-omeda-identity-x/browser';
+import SharedFloatingVideoPlayer from './floating-video-player.vue';
 
 const setP1EventsIdentity = ({ p1events, brandKey, encryptedId }) => {
   if (!p1events || !brandKey || !encryptedId) return;
@@ -36,4 +37,5 @@ export default (Browser) => {
   ContactUs(Browser);
   OmedaIdentityX(Browser);
   P1Events(Browser);
+  Browser.register('SharedFloatingVideoPlayer', SharedFloatingVideoPlayer);
 };

--- a/packages/shared/components/elements/video-player.marko
+++ b/packages/shared/components/elements/video-player.marko
@@ -1,0 +1,19 @@
+$ const { identity } = out.global.leads;
+$ const { req } = out.global;
+
+$ const identityParams = encodeURIComponent(Object.keys(identity).reduce((arr, key) => {
+  const v = identity[key];
+  if (!v) return arr;
+  const k = key === 'id' ? 'leads_idt' : 'et_usr';
+  arr.push(`${k}=${v}`);
+  return arr;
+}, []).join('&'));
+
+<marko-web-browser-component name="SharedFloatingVideoPlayer" props={
+  enabled: true,
+  identityParams: identityParams,
+  accountId: "4684385816001",
+  playerId: "kxlefI771",
+  playerEmbed: "default",
+  playlistId: "1705459835690965200"
+} />

--- a/packages/shared/components/layouts/published-content.marko
+++ b/packages/shared/components/layouts/published-content.marko
@@ -35,6 +35,7 @@ $ const withOopAds = defaultValue(input.withOopAds, true);
   </@head>
 
   <@above-container>
+    <shared-global-video-player />
     <if(withOopAds)>
       <marko-web-gam-out-of-page-ad ...GAM.getAdUnit({ name: "reskin" }) />
     </if>

--- a/packages/shared/components/layouts/website-section/default.marko
+++ b/packages/shared/components/layouts/website-section/default.marko
@@ -186,6 +186,7 @@ $ const promise = websiteSectionContentLoader(apollo, {
       <marko-web-resolve-page|{ data: section }| node=pageNode>
         <shared-fixed-ad-bottom aliases=hierarchyAliases(section) />
       </marko-web-resolve-page>
+      <shared-global-video-player />
     </@foot>
   </marko-web-website-section-page-layout>
 </marko-web-resolve>

--- a/packages/shared/components/marko.json
+++ b/packages/shared/components/marko.json
@@ -27,6 +27,9 @@
     "@content": "object",
     "@block-name": "string"
   },
+  "<shared-global-video-player>": {
+    "template": "./elements/video-player.marko"
+  },
   "<shared-native-x-inject>": {
     "template": "./native-x-inject.marko",
     "@limit": "number",

--- a/packages/shared/package.json
+++ b/packages/shared/package.json
@@ -10,6 +10,7 @@
     "test": "yarn lint"
   },
   "dependencies": {
+    "@brightcove/player-loader": "^1.8.0",
     "@industrial-media/package-contact-us": "^1.22.2",
     "@parameter1/base-cms-env": "^2.45.0",
     "@parameter1/base-cms-image": "^2.45.0",

--- a/packages/shared/templates/content/index.marko
+++ b/packages/shared/templates/content/index.marko
@@ -311,5 +311,8 @@ $ const injectAds = ["article", "news", "press-release", "blog"].includes(type) 
     <marko-web-resolve-page|{ data: section }| node=pageNode>
       <shared-fixed-ad-bottom aliases=hierarchyAliases(section) />
     </marko-web-resolve-page>
+    <if(type !== "video")>
+      <shared-global-video-player />
+    </if>
   </@foot>
 </marko-web-content-page-layout>

--- a/packages/shared/templates/dynamic-page/index.marko
+++ b/packages/shared/templates/dynamic-page/index.marko
@@ -46,5 +46,6 @@ $ const { id, alias, pageNode } = data;
   </@page>
   <@foot>
     <shared-fixed-ad-bottom />
+    <shared-global-video-player />
   </@foot>
 </marko-web-dynamic-page-layout>

--- a/yarn.lock
+++ b/yarn.lock
@@ -1239,6 +1239,19 @@
     "@babel/helper-validator-identifier" "^7.14.9"
     to-fast-properties "^2.0.0"
 
+"@brightcove/player-loader@^1.8.0":
+  version "1.8.0"
+  resolved "https://registry.yarnpkg.com/@brightcove/player-loader/-/player-loader-1.8.0.tgz#e835d7c23e0bf584a03dfefbc4640484d4b187a1"
+  integrity sha512-1JbLYEGDYfAn1N17HeXN2Rjr7Thxhi+E/sK3cU88UJtJaPTt/Oy0xFl9eKifRkmrnEy5boPsvJKywC0DRbKXAw==
+  dependencies:
+    "@brightcove/player-url" "^1.2.0"
+    global "^4.3.2"
+
+"@brightcove/player-url@^1.2.0":
+  version "1.2.0"
+  resolved "https://registry.yarnpkg.com/@brightcove/player-url/-/player-url-1.2.0.tgz#0ee48670b6299bf7a6ae30063d53f31c38468904"
+  integrity sha512-MhmB5JZAAPG3l3FbLiDrkNo5TKQI4Mp1xZmKk1y0DrIibh1loE14raabI30X3rizKT5ThTdvRmLlVMENUn7Gvw==
+
 "@evocateur/libnpmaccess@^3.1.2":
   version "3.1.2"
   resolved "https://registry.yarnpkg.com/@evocateur/libnpmaccess/-/libnpmaccess-3.1.2.tgz#ecf7f6ce6b004e9f942b098d92200be4a4b1c845"
@@ -5300,6 +5313,11 @@ dom-serializer@~0.1.0, dom-serializer@~0.1.1:
     domelementtype "^1.3.0"
     entities "^1.1.1"
 
+dom-walk@^0.1.0:
+  version "0.1.2"
+  resolved "https://registry.yarnpkg.com/dom-walk/-/dom-walk-0.1.2.tgz#0c548bef048f4d1f2a97249002236060daa3fd84"
+  integrity sha512-6QvTW9mrGeIegrFXdtQi9pk7O/nSK6lSdXW2eqUspN5LWD7UTji2Fqw5V2YLjBpHEoU9Xl/eUWNpDeZvoyOv2w==
+
 domain-browser@^1.1.1:
   version "1.2.0"
   resolved "https://registry.yarnpkg.com/domain-browser/-/domain-browser-1.2.0.tgz#3d31f50191a6749dd1375a7f522e823d42e54eda"
@@ -6729,6 +6747,14 @@ global-prefix@^3.0.0:
     ini "^1.3.5"
     kind-of "^6.0.2"
     which "^1.3.1"
+
+global@^4.3.2:
+  version "4.4.0"
+  resolved "https://registry.yarnpkg.com/global/-/global-4.4.0.tgz#3e7b105179006a323ed71aafca3e9c57a5cc6406"
+  integrity sha512-wv/LAoHdRE3BeTGz53FAamhGlPLhlssK45usmGFThIi4XqnBmjKQ16u+RNbP7WvigRZDxUsM0J3gcQ5yicaL0w==
+  dependencies:
+    min-document "^2.19.0"
+    process "^0.11.10"
 
 globals@^11.1.0, globals@^11.7.0:
   version "11.12.0"
@@ -8940,6 +8966,13 @@ mimic-fn@^2.0.0:
   version "2.1.0"
   resolved "https://registry.yarnpkg.com/mimic-fn/-/mimic-fn-2.1.0.tgz#7ed2c2ccccaf84d3ffcb7a69b57711fc2083401b"
   integrity sha512-OqbOk5oEQeAZ8WXWydlu9HJjz9WVdEIvamMCcXmuqUYjTknH/sqsWvhQ3vgwKFRR1HpjvNBKQ37nbJgYzGqGcg==
+
+min-document@^2.19.0:
+  version "2.19.0"
+  resolved "https://registry.yarnpkg.com/min-document/-/min-document-2.19.0.tgz#7bd282e3f5842ed295bb748cdd9f1ffa2c824685"
+  integrity sha1-e9KC4/WELtKVu3SM3Z8f+iyCRoU=
+  dependencies:
+    dom-walk "^0.1.0"
 
 minimalistic-assert@^1.0.0, minimalistic-assert@^1.0.1:
   version "1.0.1"


### PR DESCRIPTION
Adds a custom Vue component utilizing the Brightcove player API to render a custom player on all non-video pages.

Standard page load
<img width="1181" alt="image" src="https://user-images.githubusercontent.com/1778222/158483021-861b4f5e-9a62-4a0a-8a94-c1537fe35a56.png">

Scrolling down into push-up ad
<img width="1178" alt="image" src="https://user-images.githubusercontent.com/1778222/158483061-ea9fa665-a463-4c12-8685-19a6bcad85a4.png">
