### PR TITLE
Update footer logos into 2 separate brands

### DIFF
--- a/packages/shared/components/site-footer.marko
+++ b/packages/shared/components/site-footer.marko
@@ -1,5 +1,6 @@
 $ const { config, site } = out.global;
 $ const brandLogos = site.getAsArray("logos.footer.brandLogos");
+$ const lynchBrandLogos = site.getAsArray("logos.footer.lynchBrandLogos");
 $ const blockName = input.blockName || "site-footer";
 
 <marko-web-block
@@ -31,6 +32,27 @@ $ const blockName = input.blockName || "site-footer";
       </div>
     </default-theme-site-footer-container>
   </if>
+  <else-if(lynchBrandLogos.length)>
+    <default-theme-site-footer-container block-name=blockName modifiers=["secondary"]>
+      <div class="row brand-logos">
+        <for|logo| of=lynchBrandLogos>
+          <div class="col-3 col-sm site-footer-logo">
+              <marko-web-img
+                class="img-fluid"
+                alt=logo.alt
+                src=logo.src
+                srcset=logo.srcset
+                link= {
+                  href: logo.href,
+                  title: logo.alt,
+                  target: "_blank",
+                }
+              />
+          </div>
+        </for>
+      </div>
+    </default-theme-site-footer-container>
+  </else-if>
   <else>
     <default-theme-site-footer-container block-name=blockName modifiers=["secondary"]>
       <default-theme-site-navbar-brand block-name=blockName title=`${config.website("name")} Homepage`>

--- a/packages/shared/config/footer-brand-logos.js
+++ b/packages/shared/config/footer-brand-logos.js
@@ -56,16 +56,5 @@ module.exports = {
         'https://img.mbtmag.com/files/base/indm/all/mbt_logo.png?h=120 2x',
       ],
     },
-
-
-    // THIS SRC PATH WILL NEED TO BE CHANGED
-    {
-      href: 'https://www.medicaldesigndevelopment.com',
-      alt: 'Visit Medical Design & Development',
-      src: 'https://img.medicaldesigndevelopment.com/files/base/indm/mdd/image/static/Medical_Design_Development_Logo.png?h=60',
-      srcset: [
-        'https://img.medicaldesigndevelopment.com/files/base/indm/mdd/image/static/Medical_Design_Development_Logo.png?h=120 2x',
-      ],
-    },
   ],
 };

--- a/packages/shared/config/lynch-footer-brand-logos.js
+++ b/packages/shared/config/lynch-footer-brand-logos.js
@@ -1,0 +1,32 @@
+module.exports = {
+  lynchBrandLogos: [
+    {
+      src: 'https://img.medicaldesigndevelopment.com/files/base/indm/all/logoLM-(1)213.png?h=150',
+      srcset: [
+        'https://img.medicaldesigndevelopment.com/files/base/indm/all/logoLM-(1)213.png?h=300 2x',
+      ],
+    },
+    {
+      href: 'https://www.medicaldesigndevelopment.com',
+      alt: 'Visit Medical Design & Development',
+      src: 'https://img.medicaldesigndevelopment.com/files/base/indm/mdd/image/static/Medical_Design_Development_Logo.png?h=60',
+      srcset: [
+        'https://img.medicaldesigndevelopment.com/files/base/indm/mdd/image/static/Medical_Design_Development_Logo.png?h=120 2x',
+      ],
+    },
+    {
+      src: 'https://img.cannabisequipmentnews.com/files/base/indm/all/202final.jpeg?h=75',
+      srcset: [
+        'https://img.cannabisequipmentnews.com/files/base/indm/all/202final.jpeg?h=150 2x',
+      ],
+    },
+    {
+      href: 'https://cannabisequipmentnews.com',
+      alt: 'Visit Cannabis Equipment News',
+      src: 'https://img.cannabisequipmentnews.com/files/base/indm/all/cen_logo.jpg?h=60',
+      srcset: [
+        'https://img.cannabisequipmentnews.com/files/base/indm/all/cen_logo.jpg?h=120 2x',
+      ],
+    },
+  ],
+};

--- a/sites/cannabisequipmentnews.com/config/site.js
+++ b/sites/cannabisequipmentnews.com/config/site.js
@@ -1,3 +1,5 @@
+const { lynchBrandLogos } = require('@industrial-media/package-shared/config/lynch-footer-brand-logos');
+
 const navigation = require('./navigation');
 const gam = require('./gam');
 const nativeX = require('./native-x');
@@ -28,6 +30,7 @@ module.exports = {
       ],
     },
     footer: {
+      lynchBrandLogos,
       src: 'https://img.cannabisequipmentnews.com/files/base/indm/all/cen_logo.jpg?h=60',
       srcset: [
         'https://img.cannabisequipmentnews.com/files/base/indm/all/cen_logo.jpg?h=120 2x',

--- a/sites/medicaldesigndevelopment.com/config/site.js
+++ b/sites/medicaldesigndevelopment.com/config/site.js
@@ -1,4 +1,4 @@
-const { brandLogos } = require('@industrial-media/package-shared/config/footer-brand-logos');
+const { lynchBrandLogos } = require('@industrial-media/package-shared/config/lynch-footer-brand-logos');
 
 const navigation = require('./navigation');
 const gam = require('./gam');
@@ -30,7 +30,7 @@ module.exports = {
       ],
     },
     footer: {
-      brandLogos,
+      lynchBrandLogos,
       src: 'https://img.medicaldesigndevelopment.com/files/base/indm/mdd/image/static/Medical_Design_Development_Logo.png?h=60',
       srcset: [
         'https://img.medicaldesigndevelopment.com/files/base/indm/mdd/image/static/Medical_Design_Development_Logo.png?h=120 2x',


### PR DESCRIPTION
LYNCH MEDIA BRAND:
<img width="1235" alt="Screen Shot 2022-03-29 at 8 53 12 AM" src="https://user-images.githubusercontent.com/64623209/160628096-26807fdc-e231-4606-a4af-7d75b54d0c16.png">
<img width="1221" alt="Screen Shot 2022-03-29 at 8 55 38 AM" src="https://user-images.githubusercontent.com/64623209/160628248-6ee25c65-4377-497b-9ee5-a48194a11051.png">
INDUSTRIAL MEDIA BRAND:
<img width="1238" alt="Screen Shot 2022-03-29 at 8 53 25 AM" src="https://user-images.githubusercontent.com/64623209/160628111-0a535ac2-a0db-48d7-8690-a74dba8c92bb.png">
