### PR TITLE
Make overlay background transparent.

### DIFF
--- a/packages/shared/scss/core.scss
+++ b/packages/shared/scss/core.scss
@@ -71,3 +71,7 @@ body {
 .gsc-adBlock {
   display: none !important;
 }
+
+#brightcove-floating-player div div[class="vjs-overlay vjs-overlay-bottom vjs-overlay-background"] {
+  background-color: transparent;
+}


### PR DESCRIPTION
LIVE:
<img width="1920" alt="Screen Shot 2022-03-30 at 9 50 07 AM" src="https://user-images.githubusercontent.com/46794001/160867359-646629f2-503f-4801-b78e-3c1ce56f5f27.png">

DEV:
<img width="1920" alt="Screen Shot 2022-03-30 at 9 49 55 AM" src="https://user-images.githubusercontent.com/46794001/160867414-ceda9330-9142-446b-b017-c445e8cfc865.png">

