### PR TITLE
Reduce margin-right on mobile for byline items.

### DIFF
--- a/packages/shared/scss/components/_page.scss
+++ b/packages/shared/scss/components/_page.scss
@@ -61,6 +61,11 @@
       content: "By";
     }
   }
+  &__content-name {
+    @include media-breakpoint-down(md) {
+      margin-right: 0.2rem;
+    }
+  }
   a {
     color: $primary;
   }


### PR DESCRIPTION
BEFORE:
<img width="1792" alt="Screen Shot 2022-04-14 at 11 31 22 AM" src="https://user-images.githubusercontent.com/46794001/163433887-ed14bc3a-7488-4fea-ad88-0378851e5466.png">


AFTER:
<img width="1792" alt="Screen Shot 2022-04-14 at 11 34 24 AM" src="https://user-images.githubusercontent.com/46794001/163433900-181b5fee-2dd5-4387-8eef-23e98d3dfed2.png">
