### PR TITLE
Correct CSS targeting for overlay elements, BrightCove Player.

### DIFF
--- a/packages/shared/scss/core.scss
+++ b/packages/shared/scss/core.scss
@@ -72,6 +72,6 @@ body {
   display: none !important;
 }
 
-#brightcove-floating-player div div[class="vjs-overlay vjs-overlay-bottom vjs-overlay-background"] {
+#brightcove-floating-player div.vjs-control-bar div[class*="vjs-overlay-background"] {
   background-color: transparent;
 }


### PR DESCRIPTION
<img width="1920" alt="Screen Shot 2022-04-28 at 11 19 36 AM" src="https://user-images.githubusercontent.com/46794001/165798814-8ae5e5f7-ce80-45f8-8c0b-00838d9ceb9a.png">
