### PR TITLE
IEN-global adjustments to menu and footer

### DIFF
--- a/packages/global/components/site-footer.marko
+++ b/packages/global/components/site-footer.marko
@@ -17,44 +17,42 @@ $ const tagline = site.get("tagline");
   modifiers=input.modifiers
   attrs=input.attrs
 >
-  <default-theme-site-footer-container block-name=blockName modifiers=["secondary"]>
+  <default-theme-site-footer-container block-name=blockName modifiers=["brand-logos"]>
     <marko-web-element block-name=blockName name="inner-container">
-
       <if(brandLogos.length)>
-        <default-theme-site-footer-container block-name=blockName modifiers=["secondary"]>
-          <div class="row brand-logos">
-            <for|logo| of=brandLogos>
-              <div class="col-3 col-sm site-footer-logo">
-                  <marko-web-img
-                    class="img-fluid"
-                    alt=logo.alt
-                    src=logo.src
-                    srcset=logo.srcset
-                    link= {
-                      href: logo.href,
-                      title: logo.alt,
-                      target: "_blank",
-                    }
-                  />
-              </div>
-            </for>
-          </div>
-        </default-theme-site-footer-container>
+        <div class="row brand-logos">
+          <for|logo| of=brandLogos>
+            <div class="col-3 col-sm site-footer-logo">
+                <marko-web-img
+                  class="img-fluid"
+                  alt=logo.alt
+                  src=logo.src
+                  srcset=logo.srcset
+                  link= {
+                    href: logo.href,
+                    title: logo.alt,
+                    target: "_blank",
+                  }
+                />
+            </div>
+          </for>
+        </div>
       </if>
       <else>
-        <default-theme-site-footer-container block-name=blockName modifiers=["secondary"]>
-          <default-theme-site-navbar-brand block-name=blockName title=`${config.website("name")} Homepage`>
-            <default-theme-site-navbar-logo
-              block-name=blockName
-              alt=config.website("name")
-              src=site.get("logos.footer.src")
-              srcset=site.getAsArray("logos.footer.srcset").join(",")
-              lazyload=true
-            />
-          </default-theme-site-navbar-brand>
-        </default-theme-site-footer-container>
+        <default-theme-site-navbar-brand block-name=blockName title=`${config.website("name")} Homepage`>
+          <default-theme-site-navbar-logo
+            block-name=blockName
+            alt=config.website("name")
+            src=site.get("logos.footer.src")
+            srcset=site.getAsArray("logos.footer.srcset").join(",")
+            lazyload=true
+          />
+        </default-theme-site-navbar-brand>
       </else>
-
+    </marko-web-element>
+  </default-theme-site-footer-container>
+  <default-theme-site-footer-container block-name=blockName modifiers=["secondary"]>
+    <marko-web-element block-name=blockName name="inner-container">
       <if(tagline)>
         <marko-web-element block-name=blockName name="tagline" modifiers="tagline">${tagline}</marko-web-element>
       </if>

--- a/packages/global/components/site-menu/index.marko
+++ b/packages/global/components/site-menu/index.marko
@@ -19,8 +19,6 @@ $ const hasUser = defaultValue(input.hasUser, false);
   <marko-web-element block-name=blockName name="contents-desktop">
     <div class="row">
       <div class="col-6 col-md-4 col-lg-3">
-        <!-- search box -->
-        <search block-name=blockName />
         <!-- social -->
         <social-icons block-name=blockName title="Follow Us" />
         <!-- about section -->

--- a/packages/global/scss/components/_site-footer.scss
+++ b/packages/global/scss/components/_site-footer.scss
@@ -1,0 +1,11 @@
+.site-footer {
+  &__container {
+    &--brand-logos {
+      background-color: $white;
+      padding-bottom: 0;
+    }
+    &--secondary {
+      background-color: $gray-800;
+    }
+  }
+}

--- a/packages/global/scss/components/_site-navbar.scss
+++ b/packages/global/scss/components/_site-navbar.scss
@@ -14,3 +14,16 @@
     padding-right: 20px;
   }
 }
+
+.site-header {
+  position: fixed;
+}
+.document-container {
+  margin-top: calculate-navbar-height-for(default);
+
+  @each $breakpoint, $width in sort-map-by-values($theme-site-header-breakpoints, desc) {
+    @media (max-width: $width) {
+      margin-top: calculate-navbar-height-for($breakpoint);
+    }
+  }
+}

--- a/packages/global/scss/components/_site-navbar.scss
+++ b/packages/global/scss/components/_site-navbar.scss
@@ -18,7 +18,8 @@
 .site-header {
   position: fixed;
 }
-.document-container {
+.document-container,
+.site-newsletter-menu__container {
   margin-top: calculate-navbar-height-for(default);
 
   @each $breakpoint, $width in sort-map-by-values($theme-site-header-breakpoints, desc) {

--- a/packages/global/scss/core.scss
+++ b/packages/global/scss/core.scss
@@ -75,18 +75,17 @@
   }
 }
 
-
 // skin components
 @import "./components/blocks/magazine-issues";
 @import "./components/blocks/top-stories";
 @import "../components/magazine/scss/index";
 @import "./components/ads";
 @import "./components/node";
+@import "./components/site-footer";
 @import "./components/site-navbar-custom";
 @import "./components/site-navbar";
 @import "./components/site-newsletter-menu";
 @import "./components/brightcove-player";
-
 
 
 body {

--- a/packages/global/templates/search.marko
+++ b/packages/global/templates/search.marko
@@ -16,13 +16,6 @@ $ const apiKey = site.get("gcse.id");
   </@head>
   <@page>
     <marko-web-page-wrapper>
-      <@section modifiers=["first"]>
-        <theme-gam-define-display-ad
-          name="leaderboard"
-          position="static_page"
-          modifiers=["inter-block"]
-        />
-      </@section>
       <@section>
         <div class="row">
           <div class="col">


### PR DESCRIPTION
 - Make the header fixed to the top & adjust document container & pushdown menus margin-top
 - Remove search from drop down menu
 - Move footer logos out of secondary and into its own row with white background
 - Remove leaderboard from search page


<img width="1159" alt="Screen Shot 2022-05-13 at 9 33 23 AM" src="https://user-images.githubusercontent.com/3845869/168306983-d4e5fa7d-7a2c-46b6-908c-65c91fa79090.png">

<img width="1228" alt="Screen Shot 2022-05-13 at 9 16 33 AM" src="https://user-images.githubusercontent.com/3845869/168306967-aae263ae-ecea-43cb-977a-f242eac1d828.png">

