### PR TITLE
Update global site toggle menu & add identity x navigation

### DIFF
--- a/packages/global/browser/floating-video-player.vue
+++ b/packages/global/browser/floating-video-player.vue
@@ -117,7 +117,7 @@ export default {
   z-index: 1;
 }
 
-#brightcove-floating-player .btn {
+#brightcove-floating-player >>> .btn {
   position: absolute;
   right: 0;
   top: 0;
@@ -126,7 +126,7 @@ export default {
   width: 32px;
 }
 
-#brightcove-floating-player .vjs-control-bar div[class*="vjs-overlay-background"] {
+#brightcove-floating-player >>> .video-js .vjs-overlay {
   background-color: transparent;
 }
 

--- a/packages/global/components/document.marko
+++ b/packages/global/components/document.marko
@@ -88,15 +88,15 @@ $ const {
     />
     <marko-web-identity-x-context|{ hasUser, isEnabled }|>
       <if("navbar-custom" === site.get("navigation.type"))>
-        <global-site-header-custom has-user=false reg-enabled=false />
+        <global-site-header-custom has-user=hasUser reg-enabled=isEnabled />
       </if>
       <else-if("navbar2" === site.get("navigation.type"))>
-        <global-site-header-2 has-user=false reg-enabled=false />
+        <global-site-header-2 has-user=hasUser reg-enabled=isEnabled />
       </else-if>
       <else>
-        <global-site-header has-user=false reg-enabled=false />
+        <global-site-header has-user=hasUser reg-enabled=isEnabled />
       </else>
-      <global-site-menu has-user=false reg-enabled=false />
+      <global-site-menu has-user=hasUser reg-enabled=isEnabled />
     </marko-web-identity-x-context>
     <theme-site-newsletter-menu />
     <${input.aboveContainer} />

--- a/packages/global/components/site-menu/index.marko
+++ b/packages/global/components/site-menu/index.marko
@@ -18,21 +18,7 @@ $ const hasUser = defaultValue(input.hasUser, false);
   <!-- desktop -->
   <marko-web-element block-name=blockName name="contents-desktop">
     <div class="row">
-      <div class="col-6 col-md-4 col-lg-3">
-        <!-- social -->
-        <social-icons block-name=blockName title="Follow Us" />
-        <!-- about section -->
-        <default-theme-site-menu-section
-          tag="nav"
-          block-name=blockName
-          label="About"
-          items=site.getAsArray("navigation.desktopMenu.about")
-          modifiers=["secondary"]
-          reg-enabled=regEnabled
-          has-user=hasUser
-        />
-      </div>
-      <div class="col-6 col-md-4 col-lg-3">
+      <div class="col-6 col-md-4">
         <!-- sections -->
         <default-theme-site-menu-section
           tag="nav"
@@ -44,7 +30,7 @@ $ const hasUser = defaultValue(input.hasUser, false);
           has-user=hasUser
         />
       </div>
-      <div class="d-none d-md-flex col-md-4 col-lg-3">
+      <div class="d-none d-md-flex col-md-4">
         <!-- sections -->
         <default-theme-site-menu-section
           tag="nav"
@@ -56,24 +42,52 @@ $ const hasUser = defaultValue(input.hasUser, false);
           has-user=hasUser
         />
       </div>
-      <div class="d-none d-md-flex col-lg-3">
-        <!-- sections -->
-        <default-theme-site-menu-section
-          tag="nav"
+      <div class="d-none d-md-flex col-md-4">
+        <marko-web-element
           block-name=blockName
-          label=(site.get("navigation.toggleMenu.rightColumn.label") || "More")
-          items=site.getAsArray("navigation.toggleMenu.rightColumn.items")
+          name="section"
+          tag="nav"
           modifiers=["primary"]
-          reg-enabled=regEnabled
-          has-user=hasUser
-        />
+        >
+          <!-- Right Column Header -->
+          <default-theme-site-menu-header block-name=blockName>
+            ${ site.get("navigation.toggleMenu.rightColumn.label") || "User Tools" }
+          </default-theme-site-menu-header>
+          <!-- Identity X navigation Items -->
+          <!-- Identity X navigation Items -->
+          <default-theme-site-menu-section
+            tag="nav"
+            block-name=blockName
+            items=site.getAsArray("navigation.user.items")
+            modifiers=["user"]
+            reg-enabled=regEnabled
+            has-user=hasUser
+          />
+          <!-- Social Follow Label & items -->
+          <social-icons block-name=blockName title="Follow Us" />
+          <!-- Toggle Menu Right Column Items -->
+          <default-theme-site-navbar-items
+            block-name=blockName
+            items=site.getAsArray("navigation.toggleMenu.rightColumn.items")
+            reg-enabled=regEnabled
+            has-user=hasUser
+          />
+        </marko-web-element>
       </div>
     </div>
   </marko-web-element>
   <!-- mobile -->
   <marko-web-element block-name=blockName name="contents-mobile">
-    <!-- search box -->
-    <search block-name=blockName />
+    <!-- primary section -->
+    <!-- Identity X navigation Items -->
+    <default-theme-site-menu-section
+      tag="nav"
+      block-name=blockName
+      items=site.getAsArray("navigation.user.items")
+      modifiers=["user"]
+      reg-enabled=regEnabled
+      has-user=hasUser
+    />
     <!-- social -->
     <social-icons block-name=blockName />
     <!-- primary section -->

--- a/packages/global/components/site-menu/index.marko
+++ b/packages/global/components/site-menu/index.marko
@@ -18,7 +18,7 @@ $ const hasUser = defaultValue(input.hasUser, false);
   <!-- desktop -->
   <marko-web-element block-name=blockName name="contents-desktop">
     <div class="row">
-      <div class="col-6 col-md-4">
+      <div class="col-6 col-md-3">
         <!-- sections -->
         <default-theme-site-menu-section
           tag="nav"
@@ -30,7 +30,7 @@ $ const hasUser = defaultValue(input.hasUser, false);
           has-user=hasUser
         />
       </div>
-      <div class="d-none d-md-flex col-md-4">
+      <div class="d-none d-md-flex col-md-3">
         <!-- sections -->
         <default-theme-site-menu-section
           tag="nav"
@@ -42,7 +42,7 @@ $ const hasUser = defaultValue(input.hasUser, false);
           has-user=hasUser
         />
       </div>
-      <div class="d-none d-md-flex col-md-4">
+      <div class="d-none d-md-flex col-md-6">
         <marko-web-element
           block-name=blockName
           name="section"

--- a/packages/global/config/identity-x-nav.js
+++ b/packages/global/config/identity-x-nav.js
@@ -1,0 +1,42 @@
+const { isArray } = Array;
+
+module.exports = ({ site }) => {
+  const idxConfig = site.get('identityX');
+
+  const enabled = site.get('idxNavItems.enable');
+  if (!enabled) return;
+  const defaultTargets = [
+    'navigation.user.items',
+  ];
+  const targets = site.getAsArray('idxNavItems.navigationTargets').length ? site.getAsArray('idxNavItems.navigationTargets') : defaultTargets;
+  const navConfig = [
+    {
+      href: idxConfig.getEndpointFor('login'),
+      label: 'Sign In',
+      when: 'logged-out',
+      modifiers: ['user', 'user-login'],
+    },
+    {
+      href: idxConfig.getEndpointFor('profile'),
+      label: 'Manage Account',
+      when: 'logged-in',
+      modifiers: ['user', 'user-manage'],
+    },
+    {
+      href: idxConfig.getEndpointFor('logout'),
+      label: 'Sign Out',
+      when: 'logged-in',
+      modifiers: ['user', 'user-logout'],
+    },
+    // {
+    //   href: idxConfig.getEndpointFor('register'),
+    //   label: 'Sign Up',
+    //   when: 'logged-out',
+    //   modifiers: ['user'],
+    // },
+  ];
+  targets.forEach((target) => {
+    const nav = site.get(target);
+    if (isArray(nav)) nav.unshift(...navConfig);
+  });
+};

--- a/packages/global/scss/components/_ads.scss
+++ b/packages/global/scss/components/_ads.scss
@@ -23,8 +23,14 @@
 body .document-container > .page:first-of-type {
   margin-top: 298px;
   // excluded the following page types as they dont use reskin ads
-  &.page--search {
+  &.page--search,
+  &.page--authenticate,
+  &.page--login,
+  &.page--logout,
+  &.page--profile,
+  &.page--register {
     margin-top: 60px;
+    margin-bottom: 60px;
   }
 }
 body .document-container > .reveal-ad + .page {

--- a/packages/global/scss/components/_site-navbar.scss
+++ b/packages/global/scss/components/_site-navbar.scss
@@ -51,8 +51,12 @@
         font-weight: $font-weight-bold;
       }
     }
+  }
+  &__item {
     &--user-login {
-      color: $primary;
+      #{ $self }__link {
+        color: $primary;
+      }
     }
   }
 }

--- a/packages/global/scss/components/_site-navbar.scss
+++ b/packages/global/scss/components/_site-navbar.scss
@@ -42,3 +42,34 @@
     }
   }
 }
+
+.site-menu {
+  $self: &;
+  &__section {
+    &--user {
+      #{ $self }__link {
+        font-weight: $font-weight-bold;
+      }
+    }
+    &--user-login {
+      color: $primary;
+    }
+  }
+}
+
+// Handle layout of social icons. Most likely will move to site css
+.social-follow__section {
+  display: grid;
+  grid-template-columns: 1fr 1fr 1fr;
+  column-gap: map-get($spacers, 2);
+  row-gap: 1rem;
+}
+.social-follow--site-menu {
+  padding-bottom: map-get($spacers, block);
+  border-bottom: solid 1px $gray-200;
+}
+.social-follow__section > .social-icon-link {
+  display: inline-block;
+  margin-right: initial;
+  text-align: center;
+}

--- a/packages/global/scss/components/_site-navbar.scss
+++ b/packages/global/scss/components/_site-navbar.scss
@@ -61,19 +61,10 @@
   }
 }
 
-// Handle layout of social icons. Most likely will move to site css
-.social-follow__section {
-  display: grid;
-  grid-template-columns: 1fr 1fr 1fr;
-  column-gap: map-get($spacers, 2);
-  row-gap: 1rem;
-}
 .social-follow--site-menu {
   padding-bottom: map-get($spacers, block);
   border-bottom: solid 1px $gray-200;
 }
 .social-follow__section > .social-icon-link {
   display: inline-block;
-  margin-right: initial;
-  text-align: center;
 }

--- a/packages/global/start-server.js
+++ b/packages/global/start-server.js
@@ -20,6 +20,7 @@ const idxRouteTemplates = require('./templates/user');
 const oembedHandler = require('./oembed-handler');
 const omeda = require('./config/omeda');
 const recaptcha = require('./config/recaptcha');
+const idxNavItems = require('./config/identity-x-nav');
 
 const routes = siteRoutes => (app, siteConfig) => {
   // load contact us route
@@ -80,6 +81,7 @@ module.exports = (options = {}) => {
         idxConfig,
         idxRouteTemplates,
       });
+      idxNavItems({ site: app.locals.site });
 
       // Setup GAM.
       const gamConfig = get(options, 'siteConfig.gam');

--- a/packages/global/templates/user/authenticate.marko
+++ b/packages/global/templates/user/authenticate.marko
@@ -6,14 +6,6 @@ $ const title = "Authenticate";
 <marko-web-default-page-layout type=type title=title description=title>
   <@page>
     <marko-web-page-wrapper>
-      <@section|{ aliases }| modifiers=["first"]>
-        <theme-gam-define-display-ad
-          name="leaderboard"
-          position="static_page"
-          aliases=aliases
-          modifiers=["inter-block"]
-        />
-      </@section>
       <@section>
         <marko-web-identity-x-form-authenticate />
       </@section>

--- a/packages/global/templates/user/login.marko
+++ b/packages/global/templates/user/login.marko
@@ -12,27 +12,9 @@ $ const description = `Log in to ${config.siteName()}`;
   </@head>
   <@page>
     <marko-web-page-wrapper>
-      <@section|{ aliases }| modifiers=["first"]>
-        <theme-gam-define-display-ad
-          name="leaderboard"
-          position="static_page"
-          aliases=aliases
-          modifiers=["inter-block"]
-        />
-      </@section>
-
       <@section>
         <h1 class="page-wrapper__title">${description}</h1>
         <marko-web-identity-x-form-login />
-      </@section>
-
-      <@section|{ aliases }|>
-        <theme-gam-define-display-ad
-          name="rotation"
-          position="static_page"
-          aliases=aliases
-          modifiers=["inter-block"]
-        />
       </@section>
     </marko-web-page-wrapper>
   </@page>

--- a/packages/global/templates/user/logout.marko
+++ b/packages/global/templates/user/logout.marko
@@ -12,26 +12,9 @@ $ const description = `Log out of ${config.siteName()}`;
   </@head>
   <@page>
     <marko-web-page-wrapper>
-      <@section|{ aliases }| modifiers=["first"]>
-        <theme-gam-define-display-ad
-          name="leaderboard"
-          position="static_page"
-          aliases=aliases
-          modifiers=["inter-block"]
-        />
-      </@section>
       <@section>
         <h1 class="page-wrapper__title">${description}</h1>
         <marko-web-identity-x-form-logout />
-      </@section>
-
-      <@section|{ aliases }|>
-        <theme-gam-define-display-ad
-          name="rotation"
-          position="static_page"
-          aliases=aliases
-          modifiers=["inter-block"]
-        />
       </@section>
     </marko-web-page-wrapper>
   </@page>

--- a/packages/global/templates/user/profile.marko
+++ b/packages/global/templates/user/profile.marko
@@ -12,25 +12,9 @@ $ const description = `Complete your ${config.siteName()} user profile`;
   </@head>
   <@page>
     <marko-web-page-wrapper>
-      <@section|{ aliases }| modifiers=["first"]>
-        <theme-gam-define-display-ad
-          name="leaderboard"
-          position="static_page"
-          aliases=aliases
-          modifiers=["inter-block"]
-        />
-      </@section>
       <@section>
         <h1 class="page-wrapper__title">${description}</h1>
         <marko-web-identity-x-form-profile />
-      </@section>
-      <@section|{ aliases }|>
-        <theme-gam-define-display-ad
-          name="rotation"
-          position="static_page"
-          aliases=aliases
-          modifiers=["inter-block"]
-        />
       </@section>
     </marko-web-page-wrapper>
   </@page>

--- a/packages/global/templates/user/register.marko
+++ b/packages/global/templates/user/register.marko
@@ -12,27 +12,9 @@ $ const description = `Register on ${config.siteName()}`;
   </@head>
   <@page>
     <marko-web-page-wrapper>
-      <@section|{ aliases }| modifiers=["first"]>
-        <theme-gam-define-display-ad
-          name="leaderboard"
-          position="static_page"
-          aliases=aliases
-          modifiers=["inter-block"]
-        />
-      </@section>
-
       <@section>
         <h1 class="page-wrapper__title">${description}</h1>
         <marko-web-identity-x-form-login />
-      </@section>
-
-      <@section|{ aliases }|>
-        <theme-gam-define-display-ad
-          name="rotation"
-          position="static_page"
-          aliases=aliases
-          modifiers=["inter-block"]
-        />
       </@section>
     </marko-web-page-wrapper>
   </@page>

--- a/sites/global.ien.com/config/navigation.js
+++ b/sites/global.ien.com/config/navigation.js
@@ -68,6 +68,9 @@ module.exports = {
       link: subscribe.href,
     },
   ],
+  user: {
+    items: [],
+  },
   desktopMenu,
   mobileMenu,
   topics,

--- a/sites/global.ien.com/config/navigation.js
+++ b/sites/global.ien.com/config/navigation.js
@@ -22,20 +22,18 @@ const secondary = [
 const resources = [
   { href: '/video', label: 'Video' },
   { href: '/podcast', label: 'Podcast' },
-  { href: '/software', label: 'Software' },
-  { href: '/made-in-america', label: 'Made in America' },
   { href: '/magazine', label: 'Magazine' },
+  { href: '/contact-us', label: 'Contact Us' },
+  { href: '/page/about-us', label: 'About Us' },
+  { href: 'https://ien.formstack.com/forms/advertise_with_industrial_media', label: 'Advertise', target: '_blank' },
+  { href: '/page/privacy-policy', label: 'Privacy Policy' },
+  { href: '/page/terms-conditions', label: 'Terms & Conditions' },
+  { href: 'https://www.manufacturing.net/page/CCPA', label: 'CA Consumer Privacy Act' },
 ];
 
 const utilities = [
   { href: 'https://industrialmedia.dragonforms.com/loading.do?omedasite=ien_signup', label: 'Newsletter Signup', target: '_blank' },
   { href: 'https://tcc.dragonforms.com/loading.do?omedasite=TCC1_IEnew', label: 'Subscribe to Magazine', target: '_blank' },
-  { href: 'https://ien.formstack.com/forms/advertise_with_industrial_media', label: 'Advertise', target: '_blank' },
-  { href: '/page/about-us', label: 'About Us' },
-  { href: '/contact-us', label: 'Contact Us' },
-  { href: '/page/privacy-policy', label: 'Privacy Policy' },
-  { href: '/page/terms-conditions', label: 'Terms & Conditions' },
-  { href: 'https://www.manufacturing.net/page/CCPA', label: 'CA Consumer Privacy Act' },
 ];
 
 const mobileMenu = {
@@ -50,14 +48,7 @@ const mobileMenu = {
   ],
 };
 
-const desktopMenu = {
-  about: [
-    // ...utilities
-  ],
-  sections: [
-    ...topics,
-  ],
-};
+const desktopMenu = {};
 
 module.exports = {
   type: 'navbar-custom',

--- a/sites/global.ien.com/config/navigation.js
+++ b/sites/global.ien.com/config/navigation.js
@@ -23,12 +23,7 @@ const resources = [
   { href: '/video', label: 'Video' },
   { href: '/podcast', label: 'Podcast' },
   { href: '/magazine', label: 'Magazine' },
-  { href: '/contact-us', label: 'Contact Us' },
-  { href: '/page/about-us', label: 'About Us' },
   { href: 'https://ien.formstack.com/forms/advertise_with_industrial_media', label: 'Advertise', target: '_blank' },
-  { href: '/page/privacy-policy', label: 'Privacy Policy' },
-  { href: '/page/terms-conditions', label: 'Terms & Conditions' },
-  { href: 'https://www.manufacturing.net/page/CCPA', label: 'CA Consumer Privacy Act' },
 ];
 
 const utilities = [
@@ -101,7 +96,11 @@ module.exports = {
   },
   footer: {
     items: [
+      { href: '/contact-us', label: 'Contact Us' },
+      { href: '/page/about-us', label: 'About Us' },
       { href: '/page/privacy-policy', label: 'Privacy Policy' },
+      { href: '/page/terms-conditions', label: 'Terms & Conditions' },
+      { href: 'https://www.manufacturing.net/page/CCPA', label: 'CA Consumer Privacy Act' },
       { href: '/site-map', label: 'Site Map' },
     ],
   },

--- a/sites/global.ien.com/config/site.js
+++ b/sites/global.ien.com/config/site.js
@@ -14,6 +14,9 @@ module.exports = {
   gam,
   omedaBrandKey,
   identityX: identityX({ omedaBrandKey }),
+  idxNavItems: {
+    enable: true,
+  },
   nativeX,
   newsletter,
   socialMediaLinks,


### PR DESCRIPTION
Update toggle menu to be three column on desktop with Topics, Resources & User Tools.

I adjusted the right column to pull navigation.users.items, the social follow box and then navigation.toggleMenu.rightColumn.items.

**@TODO:** determine if the social follow menu css should stay in global or move to IEN site specifically.  

### Desktop:
<img width="1214" alt="Screen Shot 2022-05-17 at 10 54 41 AM" src="https://user-images.githubusercontent.com/3845869/168855832-5ef97863-8aae-4d8e-8ba8-3573e6a88420.png">




### Mobile:
<img width="421" alt="Screen Shot 2022-05-17 at 8 58 29 AM" src="https://user-images.githubusercontent.com/3845869/168828870-38e92f8d-d7d6-4ac6-b709-f10e51356fb3.png">

