### PR TITLE
Send url prop to fix native-x story social share

### DIFF
--- a/packages/global/templates/content/native-x-story.marko
+++ b/packages/global/templates/content/native-x-story.marko
@@ -33,7 +33,7 @@ $ const { primarySection } = content;
             <theme-primary-image-block obj=content.primaryImage />
             <marko-web-content-body block-name=blockName obj=content />
             <marko-web-social-sharing
-              url=content.siteContext.path
+              url=content.siteContext.canonicalUrl
               providers=["facebook", "linkedin", "twitter", "pinterest"]
             />
           </default-theme-page-contents>

--- a/packages/global/templates/content/native-x-story.marko
+++ b/packages/global/templates/content/native-x-story.marko
@@ -33,7 +33,7 @@ $ const { primarySection } = content;
             <theme-primary-image-block obj=content.primaryImage />
             <marko-web-content-body block-name=blockName obj=content />
             <marko-web-social-sharing
-              path=content.siteContext.path
+              url=content.siteContext.path
               providers=["facebook", "linkedin", "twitter", "pinterest"]
             />
           </default-theme-page-contents>


### PR DESCRIPTION
Update to use the url prop vs the path prop which was adding the domain twice.

```js
$ let printUrl;
$ if (input.printUrl) {
  printUrl = input.printUrl;
} else if (input.printPath) {
  printUrl = `${out.global.requestOrigin}/${cleanPath(input.printPath)}`;
}
```