### PR TITLE
add IntersectionObserver for floating video comp.

### DIFF
--- a/packages/global/browser/floating-video-player.vue
+++ b/packages/global/browser/floating-video-player.vue
@@ -116,7 +116,6 @@ export default {
   methods: {
     setAutoPlayObserver() {
       if (this.autoPlayObserver) this.autoPlayObserver.disconnect();
-      console.log(this.autoPlayObserver);
       const header = document.getElementsByClassName('site-header')[0];
       const rootMargin = `-${header.offsetTop + header.offsetHeight}px 0px 0px 0px`;
       const options = {
@@ -125,7 +124,6 @@ export default {
       };
       this.autoPlayObserver = new IntersectionObserver((entries) => {
         entries.forEach((entry) => {
-          console.log(entry.intersectionRatio);
           if (!entry.intersectionRatio || entry.intersectionRatio <= 0.75) {
             this.player.pause();
           } else {

--- a/packages/global/browser/floating-video-player.vue
+++ b/packages/global/browser/floating-video-player.vue
@@ -79,6 +79,9 @@ export default {
           videoId: this.videoId,
           playlistId: this.playlistId,
           refNode: this.$el,
+          options: {
+            autoplay: false,
+          },
           embedOptions: {
             responsive: {
               maxWidth: '340px',


### PR DESCRIPTION
Add an intersection Observer to play/pause the floating video player when scrolling it on/off screen.  Set the autoplay option on load to false.  This allows the new observer to determine if it is inView before triggering the start of the view.