### PR TITLE
Rearrange navigation and menu items

### DIFF
--- a/sites/cannabisequipmentnews.com/config/navigation.js
+++ b/sites/cannabisequipmentnews.com/config/navigation.js
@@ -15,8 +15,9 @@ const topics = sortNavItems([
 
 const secondary = [
   { href: '/video', label: 'Video' },
-  { href: '/podcast', label: 'Podcast' },
   { href: 'https://ien.formstack.com/forms/advertise_with_industrial_media', label: 'Advertise', target: '_blank' },
+  { href: 'https://lynchmedia.dragonforms.com/loading.do?omedasite=cen_signup', label: 'Newsletter Signup', target: '_blank' },
+  { href: '/podcast', label: 'Podcast' },
 ];
 
 const resources = [

--- a/sites/designdevelopmenttoday.com/config/navigation.js
+++ b/sites/designdevelopmenttoday.com/config/navigation.js
@@ -9,15 +9,16 @@ const topics = sortNavItems([
   { href: '/industries/military', label: 'Military' },
   { href: '/news', label: 'News' },
   { href: '/new-products', label: 'New Products' },
-  { href: '/video', label: 'Video' },
 ]);
 
 const secondary = [
-  { href: '/contact-us', label: 'Contact Us' },
+  { href: '/video', label: 'Video' },
   { href: 'https://ien.formstack.com/forms/advertise_with_industrial_media', label: 'Advertise', target: '_blank' },
+  { href: 'https://industrialmedia.dragonforms.com/loading.do?omedasite=ddt_signup', label: 'Newsletter Signup', target: '_blank' },
 ];
 
 const resources = [
+  { href: '/video', label: 'Video' },
   { href: '/contact-us', label: 'Contact Us' },
   { href: 'https://ien.formstack.com/forms/advertise_with_lynch_media', label: 'Advertise', target: '_blank' },
 ];

--- a/sites/foodmanufacturing.com/config/navigation.js
+++ b/sites/foodmanufacturing.com/config/navigation.js
@@ -15,9 +15,12 @@ const topics = sortNavItems([
 
 const secondary = [
   { href: '/video', label: 'Video' },
+  { href: 'https://ien.formstack.com/forms/advertise_with_lynch_media', label: 'Advertise', target: '_blank' },
+  { href: 'https://industrialmedia.dragonforms.com/loading.do?omedasite=fm_signup', label: 'Newsletter Signup', target: '_blank' },
 ];
 
 const resources = [
+  { href: '/video', label: 'Video' },
   { href: '/contact-us', label: 'Contact Us' },
   { href: 'https://ien.formstack.com/forms/advertise_with_lynch_media', label: 'Advertise', target: '_blank' },
 ];

--- a/sites/ien.com/config/navigation.js
+++ b/sites/ien.com/config/navigation.js
@@ -16,8 +16,9 @@ const topics = sortNavItems([
 
 const secondary = [
   { href: '/video', label: 'Video' },
-  { href: '/podcast', label: 'Podcast' },
   { href: 'https://ien.formstack.com/forms/advertise_with_industrial_media', label: 'Advertise', target: '_blank' },
+  { href: 'https://industrialmedia.dragonforms.com/loading.do?omedasite=ien_signup', label: 'Newsletter Signup', target: '_blank' },
+  { href: '/podcast', label: 'Podcast' },
   { href: '/magazine', label: 'Magazine' },
 ];
 

--- a/sites/impomag.com/config/navigation.js
+++ b/sites/impomag.com/config/navigation.js
@@ -12,6 +12,8 @@ const topics = sortNavItems([
 
 const secondary = [
   { href: '/video', label: 'Video' },
+  { href: 'https://ien.formstack.com/forms/advertise_with_industrial_media', label: 'Advertise', target: '_blank' },
+  { href: 'https://industrialmedia.dragonforms.com/loading.do?omedasite=impo_signup', label: 'Newsletter Signup', target: '_blank' },
 ];
 
 const resources = [

--- a/sites/inddist.com/config/navigation.js
+++ b/sites/inddist.com/config/navigation.js
@@ -15,8 +15,9 @@ const topics = sortNavItems([
 
 const secondary = [
   { href: '/video', label: 'Video' },
+  { href: 'https://ien.formstack.com/forms/advertise_with_industrial_media', label: 'Advertise', target: '_blank' },
+  { href: 'https://industrialmedia.dragonforms.com/loading.do?omedasite=id_signup', label: 'Newsletter Signup', target: '_blank' },
   { href: '/magazine', label: 'Magazine' },
-  { href: '/big-50', label: 'Big 50' },
 ];
 
 const resources = [
@@ -71,6 +72,7 @@ module.exports = {
     leftColumn: {
       label: 'Topics',
       items: [
+        { href: '/big-50', label: 'Big 50' },
         ...topics,
       ],
     },

--- a/sites/manufacturing.net/config/navigation.js
+++ b/sites/manufacturing.net/config/navigation.js
@@ -13,10 +13,13 @@ const topics = sortNavItems([
 
 const secondary = [
   { href: '/video', label: 'Video' },
+  { href: 'https://ien.formstack.com/forms/advertise_with_industrial_media', label: 'Advertise', target: '_blank' },
+  { href: 'https://industrialmedia.dragonforms.com/loading.do?omedasite=mnet_signup', label: 'Newsletter Signup', target: '_blank' },
   { href: '/podcast', label: 'Podcast' },
 ];
 
 const resources = [
+  { href: '/video', label: 'Video' },
   { href: '/page/mnet-about-us', label: 'About Us' },
   { href: '/contact-us', label: 'Contact Us' },
   { href: 'https://ien.formstack.com/forms/advertise_with_industrial_media', label: 'Advertise', target: '_blank' },

--- a/sites/mbtmag.com/config/navigation.js
+++ b/sites/mbtmag.com/config/navigation.js
@@ -13,9 +13,12 @@ const topics = sortNavItems([
 
 const secondary = [
   { href: '/video', label: 'Video' },
+  { href: 'https://ien.formstack.com/forms/advertise_with_industrial_media', label: 'Advertise', target: '_blank' },
+  { href: 'https://industrialmedia.dragonforms.com/loading.do?omedasite=mbt_signup', label: 'Newsletter Signup', target: '_blank' },
 ];
 
 const resources = [
+  { href: '/video', label: 'Video' },
   { href: '/page/mbt-about-us', label: 'About Us' },
   { href: '/contact-us', label: 'Contact Us' },
   { href: 'https://ien.formstack.com/forms/advertise_with_industrial_media', label: 'Advertise', target: '_blank' },

--- a/sites/medicaldesigndevelopment.com/config/navigation.js
+++ b/sites/medicaldesigndevelopment.com/config/navigation.js
@@ -11,11 +11,13 @@ const topics = sortNavItems([
 ]);
 
 const secondary = [
-  { href: '/contact-us', label: 'Contact Us' },
+  { href: '/video', label: 'Video' },
   { href: 'https://ien.formstack.com/forms/advertise_with_lynch_media', label: 'Advertise', target: '_blank' },
+  { href: 'https://lynchmedia.dragonforms.com/loading.do?omedasite=cenmeddesdev_signup', label: 'Newsletter Signup', target: '_blank' },
 ];
 
 const resources = [
+  { href: '/video', label: 'Video' },
   { href: '/page/about-us', label: 'About Us' },
   { href: '/contact-us', label: 'Contact Us' },
   { href: 'https://ien.formstack.com/forms/advertise_with_industrial_media', label: 'Advertise', target: '_blank' },


### PR DESCRIPTION
If 'Video' was in Secondary, add to 'Resources' as well for consistency across the board
on ID: 'Big 50' is moved to 'Topics' in hamburger menu
<img width="1229" alt="Screen Shot 2022-08-25 at 11 15 15 AM" src="https://user-images.githubusercontent.com/64623209/186719264-bcf00439-b1e6-4ac1-b410-c4c054a54401.png">
<img width="1218" alt="Screen Shot 2022-08-25 at 11 03 06 AM" src="https://user-images.githubusercontent.com/64623209/186719292-cb706e30-f9ad-4524-90a8-977ca790a0d3.png">
<img width="1287" alt="Screen Shot 2022-08-25 at 11 16 47 AM" src="https://user-images.githubusercontent.com/64623209/186719330-83ee1177-f389-41ff-b1ff-58b5dbf4a202.png">
<img width="1221" alt="Screen Shot 2022-08-25 at 11 17 41 AM" src="https://user-images.githubusercontent.com/64623209/186719354-3b3e6387-51df-4006-8645-a76922c6d511.png">
<img width="1214" alt="Screen Shot 2022-08-25 at 11 18 23 AM" src="https://user-images.githubusercontent.com/64623209/186719371-b02ab8b1-b8c7-4b4a-bf28-20d016898756.png">
<img width="1294" alt="Screen Shot 2022-08-25 at 11 19 15 AM" src="https://user-images.githubusercontent.com/64623209/186719389-12f9ec3a-a7f2-4fa2-a8bd-fe2a61680cdb.png">
<img width="1205" alt="Screen Shot 2022-08-25 at 11 22 31 AM" src="https://user-images.githubusercontent.com/
<img width="1212" alt="Screen Shot 2022-08-25 at 11 23 39 AM" src="https://user-images.githubusercontent.com/64623209/186719481-bb3ef95f-4eda-456e-aad0-d41ca93613a9.png">
64623209/186719408-65d69f94-9fd4-4a20-abe6-2afa029defd8.png">
<img width="1209" alt="Screen Shot 2022-08-25 at 11 22 47 AM" src="https://user-images.githubusercontent.com/64623209/186719449-a8fbc28d-f097-49c0-b689-192c7c4e8039.png">

