### PR TITLE
Adjust how caption/credit displays on content pages

### DIFF
--- a/packages/global/scss/components/_content-page.scss
+++ b/packages/global/scss/components/_content-page.scss
@@ -6,3 +6,53 @@
     }
   }
 }
+.content-page-body {
+  .primary-image {
+    &__image-caption,
+    &__image-credit {
+      display: block;
+      line-height: inherit;
+    }
+    &__image-credit::before {
+      font-weight: $font-weight-bold;
+    }
+    div:nth-child(2):not(.primary-image__wrapper) {
+      padding-top: map-get($spacers, 2);
+    }
+    div:last-child:not(.primary-image__wrapper) {
+      width: 100%;
+      border-bottom: solid 1px $gray-200;
+      padding-bottom: map-get($spacers, 2);
+    }
+  }
+
+  p > [data-embed-type=image] {
+    picture {
+      display: flex;
+      flex-direction: column;
+      img {
+        margin-right: auto;
+        margin-left: auto;
+      }
+    }
+
+
+    .caption,
+    .credit {
+      padding: 0;
+      display: block;
+      font-size: 12px;
+    }
+    .credit:before {
+      font-weight: $font-weight-bold;
+    }
+    span:first-of-type {
+      padding-top: map-get($spacers, 2);
+    }
+    span:last-child {
+      width: 100%;
+      border-bottom: solid 1px $gray-200;
+      padding-bottom: map-get($spacers, 2);
+    }
+  }
+}

--- a/packages/global/scss/components/_content-page.scss
+++ b/packages/global/scss/components/_content-page.scss
@@ -11,6 +11,8 @@
     &__image-caption,
     &__image-credit {
       display: block;
+      padding: 0;
+      font-size: 12px;
       line-height: inherit;
     }
     &__image-credit::before {


### PR DESCRIPTION
Make the styling for primary & imbedded images match.

![ienImageCaptionCredit](https://user-images.githubusercontent.com/3845869/189728455-e8874650-bfd3-47b3-a293-7ac7b954ecda.jpg)
