### PR TITLE
Replace ‘Workforce’ & ‘Big 50’ in primary nav

### DIFF
--- a/sites/inddist.com/config/navigation.js
+++ b/sites/inddist.com/config/navigation.js
@@ -10,7 +10,7 @@ const topics = sortNavItems([
   { href: '/sales', label: 'Sales' },
   { href: '/staffing-changes', label: 'Staffing Changes' },
   { href: '/supply-chain', label: 'Supply Chain' },
-  { href: '/workforce-development', label: 'Workforce' },
+  { href: '/big-50', label: 'Big 50' },
 ]);
 
 const secondary = [
@@ -72,8 +72,8 @@ module.exports = {
     leftColumn: {
       label: 'Topics',
       items: [
-        { href: '/big-50', label: 'Big 50' },
         ...topics,
+        { href: '/workforce-development', label: 'Workforce' },
       ],
     },
     midColumn: {


### PR DESCRIPTION
<img width="1354" alt="Screen Shot 2022-09-21 at 11 40 24 AM" src="https://user-images.githubusercontent.com/64623209/191562632-918b6db8-1cd8-4cb5-8061-44cae3bde70f.png">
