### PR TITLE
Lower opacity of video icons, non-hero video items.

### DIFF
--- a/packages/global/scss/components/_node.scss
+++ b/packages/global/scss/components/_node.scss
@@ -96,4 +96,16 @@
       }
     }
   }
+
+  &--top-stories {
+    &.node--video-content-type {
+      #{ $self } {
+        &__image-inner-wrapper {
+          &::after {
+            opacity: .6;
+          }
+        }
+      }
+    }
+  }
 }

--- a/packages/global/scss/core.scss
+++ b/packages/global/scss/core.scss
@@ -151,6 +151,17 @@ label {
   &__header {
     padding-bottom: 0;
   }
+  &__node {
+    .node--video-content-type {
+      .node {
+        &__image-inner-wrapper {
+          &::after {
+            opacity: .6;
+          }
+        }
+      }
+    }
+  }
 }
 
 .card-deck-flow {


### PR DESCRIPTION
![VIdeo-Icon-Opacity](https://user-images.githubusercontent.com/46794001/191791933-2fbab688-4ecd-4cc7-936b-8d2e7f33ec9e.png)
