### PR TITLE
Correct Website spelling, only display respective fields if populated on Company pages.

### DIFF
--- a/packages/global/components/layouts/content/company-details.marko
+++ b/packages/global/components/layouts/content/company-details.marko
@@ -36,14 +36,20 @@ $ const showFields = fields.some(k => content[k]);
 
   <if(showFields)>
     <default-theme-content-contact-details-section block-name=blockName>
+    <if(content.publicEmail)>
+    $ console.log(content.publicEmail);
       <div class=`${blockName}__field`>
         <span class=`${blockName}__label`>eMail:</span>
         <marko-web-content-public-email block-name=blockName obj=content link=true/>
       </div>
+    </if>
+    <if(content.website)>
+    $ console.log(content.website);
       <div class=`${blockName}__field`>
-        <span class=`${blockName}__label`>Webiste:</span>
+        <span class=`${blockName}__label`>Website:</span>
         <marko-web-content-website block-name=blockName obj=content link=true />
       </div>
+    </if>
     </default-theme-content-contact-details-section>
   </if>
 

--- a/packages/global/components/layouts/content/company-details.marko
+++ b/packages/global/components/layouts/content/company-details.marko
@@ -36,20 +36,18 @@ $ const showFields = fields.some(k => content[k]);
 
   <if(showFields)>
     <default-theme-content-contact-details-section block-name=blockName>
-    <if(content.publicEmail)>
-    $ console.log(content.publicEmail);
-      <div class=`${blockName}__field`>
-        <span class=`${blockName}__label`>eMail:</span>
-        <marko-web-content-public-email block-name=blockName obj=content link=true/>
-      </div>
-    </if>
-    <if(content.website)>
-    $ console.log(content.website);
-      <div class=`${blockName}__field`>
-        <span class=`${blockName}__label`>Website:</span>
-        <marko-web-content-website block-name=blockName obj=content link=true />
-      </div>
-    </if>
+      <if(content.publicEmail)>
+        <div class=`${blockName}__field`>
+          <span class=`${blockName}__label`>eMail:</span>
+          <marko-web-content-public-email block-name=blockName obj=content link=true/>
+        </div>
+      </if>
+      <if(content.website)>
+        <div class=`${blockName}__field`>
+          <span class=`${blockName}__label`>Website:</span>
+          <marko-web-content-website block-name=blockName obj=content link=true />
+        </div>
+      </if>
     </default-theme-content-contact-details-section>
   </if>
 


### PR DESCRIPTION
![Master-Bond](https://user-images.githubusercontent.com/46794001/193063245-3793c41b-fb39-42fb-8686-fe7af889aa61.png)
