### PR TITLE
Update dynamic pages & create unique contact-us page

### DIFF
--- a/packages/global/components/layouts/dynamic-page/index.marko
+++ b/packages/global/components/layouts/dynamic-page/index.marko
@@ -1,0 +1,60 @@
+import hierarchyAliases from "@parameter1/base-cms-marko-web/utils/hierarchy-aliases";
+import { getAsArray, get } from "@parameter1/base-cms-object-path";
+
+$ const { id, type, pageNode, href } = input;
+$ const { GAM } = out.global;
+<theme-content-page id=id type=type >
+  <@head>
+    <marko-web-gtm-content-context|{ context }| id=id>
+      <marko-web-gtm-push data=context />
+    </marko-web-gtm-content-context>
+    <marko-web-resolve-page|{ data: content }| node=pageNode>
+      <marko-web-p1-events-track-content node=content />
+    </marko-web-resolve-page>
+  </@head>
+  <@above-container>
+    <marko-web-resolve-page|{ data: content }| node=pageNode>
+      $ const aliases = hierarchyAliases(content.primarySection);
+      <global-reveal-ad-handler select-all-targets=true path=GAM.getAdUnit({ name: "reskin", aliases }).path id="reveal-ad" />
+    </marko-web-resolve-page>
+  </@above-container>
+  <@page>
+    <marko-web-resolve-page|{ data: content }| node=pageNode>
+      $ const aliases = hierarchyAliases(content.primarySection);
+      <marko-web-page-wrapper>
+        <@section|{ blockName }|>
+          $ const { primarySection } = content;
+          <div class="content-page-header">
+            <theme-content-page-breadcrumbs section=primarySection />
+            <marko-web-content-name tag="h1" block-name=blockName obj=content />
+          </div>
+        </@section>
+
+        <@section|{ blockName }|>
+          <div class="row">
+            <div class="col-lg-8">
+              <div class="content-page-body">
+                <default-theme-page-contents|{ blockName }| attrs={ "data-gallery-id": id }>
+
+                  $ const bodyId = `content-body-${content.id}`;
+                  <marko-web-content-body block-name=blockName obj=content attrs={ id: bodyId } />
+
+                </default-theme-page-contents>
+              </div>
+            </div>
+            <if(input.rails)>
+              <div class="col-lg-4">
+                <${input.rails[0].renderBody} />
+              </div>
+            </if>
+          </div>
+        </@section>
+      </marko-web-page-wrapper>
+    </marko-web-resolve-page>
+  </@page>
+  <@foot>
+    <marko-web-resolve-page|{ data: content }| node=pageNode>
+      <global-fixed-ad-bottom aliases=hierarchyAliases(content.primarySection) />
+    </marko-web-resolve-page>
+  </@foot>
+</theme-content-page>

--- a/packages/global/components/layouts/dynamic-page/marko.json
+++ b/packages/global/components/layouts/dynamic-page/marko.json
@@ -1,0 +1,18 @@
+{
+  "<global-dynamic-page-index-layout>": {
+    "template": "./index.marko",
+    "<head>": {},
+    "@sections <section>[]": {},
+    "@id": "number",
+    "@alias": "string",
+    "@name": "string",
+    "@page-node": "object",
+    "<loader>": {
+      "<featured-params>": {},
+      "<standard-params>": {},
+      "@with-standard-query": "boolean"
+    },
+    "@right-rail-header": "string",
+    "@rails <rail>[]": {}
+  }
+}

--- a/packages/global/components/layouts/marko.json
+++ b/packages/global/components/layouts/marko.json
@@ -1,6 +1,7 @@
 {
   "taglib-imports": [
     "./content/marko.json",
-    "./website-section/marko.json"
+    "./website-section/marko.json",
+    "./dynamic-page/marko.json"
   ]
 }

--- a/packages/global/routes/dynamic-page.js
+++ b/packages/global/routes/dynamic-page.js
@@ -1,9 +1,15 @@
 const { withDynamicPage } = require('@parameter1/base-cms-marko-web/middleware');
 const queryFragment = require('@parameter1/base-cms-marko-web-theme-monorail/graphql/fragments/dynamic-page');
-const page = require('../templates/dynamic-page');
+const page = require('../templates/dynamic-page/index');
+const contactUs = require('../templates/dynamic-page/contact-us');
 
 module.exports = (app) => {
-  app.get('/page/:alias(*)', withDynamicPage({
+  app.get('/page/:alias(contact-us)', withDynamicPage({
+    template: contactUs,
+    queryFragment,
+  }));
+
+  app.get('/page/:alias([\\w\\d-]{1,})', withDynamicPage({
     template: page,
     queryFragment,
   }));

--- a/packages/global/templates/dynamic-page/contact-us.marko
+++ b/packages/global/templates/dynamic-page/contact-us.marko
@@ -1,0 +1,18 @@
+import defaultValue from "@parameter1/base-cms-marko-core/utils/default-value";
+import { get } from "@parameter1/base-cms-object-path";
+
+$ const { id, alias, name, pageNode } = input;
+$ const { site } = out.global;
+$ const contactUs = site.get('contactUs');
+$ const title = get(contactUs, 'title');
+
+<global-dynamic-page-index-layout
+  id=id
+  alias=alias
+  name=name
+  page-node=pageNode
+>
+  <@rail>
+    <contact-us-form config-name="notificationDefaults" title=title />
+  </@rail>
+</global-dynamic-page-index-layout>

--- a/packages/global/templates/dynamic-page/index.marko
+++ b/packages/global/templates/dynamic-page/index.marko
@@ -1,58 +1,9 @@
-import hierarchyAliases from "@parameter1/base-cms-marko-web/utils/hierarchy-aliases";
-import { getAsArray, get } from "@parameter1/base-cms-object-path";
+$ const { id, alias, name, pageNode } = input;
 
-$ const { id, type, pageNode } = input;
-$ const { GAM } = out.global;
-<theme-content-page id=id type=type >
-  <@head>
-    <marko-web-gtm-content-context|{ context }| id=id>
-      <marko-web-gtm-push data=context />
-    </marko-web-gtm-content-context>
-    <marko-web-resolve-page|{ data: content }| node=pageNode>
-      <marko-web-p1-events-track-content node=content />
-    </marko-web-resolve-page>
-  </@head>
-  <@above-container>
-    <marko-web-resolve-page|{ data: content }| node=pageNode>
-      $ const aliases = hierarchyAliases(content.primarySection);
-      <global-reveal-ad-handler select-all-targets=true path=GAM.getAdUnit({ name: "reskin", aliases }).path id="reveal-ad" />
-    </marko-web-resolve-page>
-  </@above-container>
-  <@page>
-    <marko-web-resolve-page|{ data: content }| node=pageNode>
-      $ const aliases = hierarchyAliases(content.primarySection);
-      <marko-web-page-wrapper>
-        <@section|{ blockName }|>
-          $ const { primarySection } = content;
-          <div class="content-page-header">
-            <theme-content-page-breadcrumbs section=primarySection />
-            <marko-web-content-name tag="h1" block-name=blockName obj=content />
-          </div>
-        </@section>
-
-        <@section|{ blockName }|>
-          <div class="row">
-            <div class="col-lg-8">
-              <div class="content-page-body">
-                <default-theme-page-contents|{ blockName }| attrs={ "data-gallery-id": id }>
-
-                  $ const bodyId = `content-body-${content.id}`;
-                  <marko-web-content-body block-name=blockName obj=content attrs={ id: bodyId } />
-
-                </default-theme-page-contents>
-              </div>
-            </div>
-            <div class="col-lg-4">
-              <contact-us-form config-name="notificationDefaults"/>
-            </div>
-          </div>
-        </@section>
-      </marko-web-page-wrapper>
-    </marko-web-resolve-page>
-  </@page>
-  <@foot>
-    <marko-web-resolve-page|{ data: content }| node=pageNode>
-      <global-fixed-ad-bottom aliases=hierarchyAliases(content.primarySection) />
-    </marko-web-resolve-page>
-  </@foot>
-</theme-content-page>
+<global-dynamic-page-index-layout
+  id=id
+  alias=alias
+  name=name
+  page-node=pageNode
+>
+</global-dynamic-page-index-layout>

--- a/sites/cannabisequipmentnews.com/config/site.js
+++ b/sites/cannabisequipmentnews.com/config/site.js
@@ -53,6 +53,7 @@ module.exports = {
     description: '',
   },
   contactUs: {
+    title: 'Submit a comment.',
     notificationDefaults: {
       to: 'david@cannabisequipmentnews.com',
       branding: {

--- a/sites/designdevelopmenttoday.com/config/site.js
+++ b/sites/designdevelopmenttoday.com/config/site.js
@@ -53,6 +53,7 @@ module.exports = {
     description: '',
   },
   contactUs: {
+    title: 'Submit a comment.',
     notificationDefaults: {
       to: 'david@ien.com',
       branding: {

--- a/sites/foodmanufacturing.com/config/site.js
+++ b/sites/foodmanufacturing.com/config/site.js
@@ -52,6 +52,7 @@ module.exports = {
     description: '',
   },
   contactUs: {
+    title: 'Submit a comment.',
     notificationDefaults: {
       to: 'david@ien.com',
       branding: {

--- a/sites/ien.com/config/site.js
+++ b/sites/ien.com/config/site.js
@@ -58,6 +58,7 @@ module.exports = {
     description: '',
   },
   contactUs: {
+    title: 'Submit a comment.',
     notificationDefaults: {
       to: 'david@ien.com',
       branding: {

--- a/sites/impomag.com/config/site.js
+++ b/sites/impomag.com/config/site.js
@@ -52,6 +52,7 @@ module.exports = {
     description: '',
   },
   contactUs: {
+    title: 'Submit a comment.',
     notificationDefaults: {
       to: 'david@ien.com',
       branding: {

--- a/sites/inddist.com/config/site.js
+++ b/sites/inddist.com/config/site.js
@@ -54,6 +54,7 @@ module.exports = {
     description: '',
   },
   contactUs: {
+    title: 'Submit a comment.',
     notificationDefaults: {
       to: 'david@ien.com',
       branding: {

--- a/sites/manufacturing.net/config/site.js
+++ b/sites/manufacturing.net/config/site.js
@@ -52,6 +52,7 @@ module.exports = {
     description: '',
   },
   contactUs: {
+    title: 'Submit a comment.',
     notificationDefaults: {
       to: 'david@ien.com',
       branding: {

--- a/sites/mbtmag.com/config/site.js
+++ b/sites/mbtmag.com/config/site.js
@@ -52,6 +52,7 @@ module.exports = {
     description: '',
   },
   contactUs: {
+    title: 'Submit a comment.',
     notificationDefaults: {
       to: 'david@ien.com',
       branding: {

--- a/sites/medicaldesigndevelopment.com/config/site.js
+++ b/sites/medicaldesigndevelopment.com/config/site.js
@@ -53,6 +53,7 @@ module.exports = {
     description: '',
   },
   contactUs: {
+    title: 'Submit a comment.',
     notificationDefaults: {
       to: 'david@ien.com',
       branding: {


### PR DESCRIPTION
dynamic pages have no form in right rail:
<img width="911" alt="Screen Shot 2022-11-01 at 7 58 49 AM" src="https://user-images.githubusercontent.com/64623209/199240261-ba6d238b-fcf4-4100-ada6-ab54efb827b4.png">
/page/contact-us will show form with updated title (**requires [base-cms PR](https://github.com/parameter1/base-cms/pull/468)**): https://github.com/parameter1/industrial-media-websites/pull/279:
<img width="1020" alt="Screen Shot 2022-11-01 at 7 58 59 AM" src="https://user-images.githubusercontent.com/64623209/199240374-ca851cc2-59fc-45fd-baba-bbd8fd7f2946.png">
/page/contact-us will show default title 'Drop us a line!') if one isn't provided:
<img width="1242" alt="Screen Shot 2022-11-01 at 8 00 18 AM" src="https://user-images.githubusercontent.com/64623209/199240570-7fb4dcbb-0c3c-48da-8db9-1ca17040ed02.png">
