### PR TITLE
Verify transcript field is non-empty before displaying

### DIFF
--- a/packages/global/components/layouts/content/default.marko
+++ b/packages/global/components/layouts/content/default.marko
@@ -1,6 +1,7 @@
 import { get, getAsArray } from "@parameter1/base-cms-object-path";
 import defaultValue from "@parameter1/base-cms-marko-core/utils/default-value";
 import getContentPreview from "@parameter1/base-cms-marko-web-theme-monorail/utils/get-content-preview";
+import verifyNonEmptyHTML from '../../../utils/verify-non-empty-html';
 
 
 $ const { site } = out.global;
@@ -23,6 +24,7 @@ $ const displaySocialShare = ["contact"].includes(type) ? false : true;
 $ const displayComments = (site.get('identityX.comments.enabled') && !["contact"].includes(type)) ? true : false;
 $ const displayNewsletterSignup = ["contact"].includes(type) ? false : true;
 $ const shouldInjectAds = ["article", "video", "news", "podcast"].includes(type);
+$ const displayTranscript = content.transcript && verifyNonEmptyHTML(content.transcript);
 
 <global-content-wrapper-layout
   id=id
@@ -72,7 +74,7 @@ $ const shouldInjectAds = ["article", "video", "news", "podcast"].includes(type)
           <theme-page-contents|{ blockName }| attrs={ "data-gallery-id": id }>
             <if(content.embedCode)>
               <global-content-embed-code block-name=blockName content=content />
-              <if(content.transcript)>
+              <if(displayTranscript)>
                 <marko-web-link href=`#transcript-${id}` class="btn btn-transcript mt-block mb-2" title="Transcript">
                   <marko-web-icon name="file" modifiers=["lg"] /> Transcript
                 </marko-web-link>
@@ -156,7 +158,7 @@ $ const shouldInjectAds = ["article", "video", "news", "podcast"].includes(type)
 
                 <marko-web-content-body block-name=blockName obj=content attrs={ id: bodyId } />
 
-                <if(content.transcript)>
+                <if(displayTranscript)>
                   $ const transcriptId = `content-transcript-${content.id}`;
                   <if(shouldInjectAds)>
                     <theme-gam-inject-ads selector=`#${transcriptId}` detect-embeds=true>

--- a/packages/global/package.json
+++ b/packages/global/package.json
@@ -40,6 +40,7 @@
     "@parameter1/omeda-graphql-client-express": "^0.4.2",
     "@trevoreyre/autocomplete-vue": "^2.2.0",
     "body-parser": "^1.19.0",
+    "cheerio": "1.0.0-rc.10",
     "express": "^4.17.1",
     "graphql": "^14.5.4",
     "graphql-tag": "^2.10.1",

--- a/packages/global/utils/verify-non-empty-html.js
+++ b/packages/global/utils/verify-non-empty-html.js
@@ -1,0 +1,7 @@
+const cheerio = require('cheerio');
+
+module.exports = (html) => {
+  const $ = cheerio.load(html);
+  if ($.text()) return true;
+  return false;
+};

--- a/yarn.lock
+++ b/yarn.lock
@@ -4312,19 +4312,7 @@ cheerio-select@^1.5.0:
     domhandler "^4.2.0"
     domutils "^2.7.0"
 
-cheerio@1.0.0-rc.2:
-  version "1.0.0-rc.2"
-  resolved "https://registry.yarnpkg.com/cheerio/-/cheerio-1.0.0-rc.2.tgz#4b9f53a81b27e4d5dac31c0ffd0cfa03cc6830db"
-  integrity sha1-S59TqBsn5NXawxwP/Qz6A8xoMNs=
-  dependencies:
-    css-select "~1.2.0"
-    dom-serializer "~0.1.0"
-    entities "~1.1.1"
-    htmlparser2 "^3.9.1"
-    lodash "^4.15.0"
-    parse5 "^3.0.1"
-
-cheerio@^1.0.0-rc.10:
+cheerio@1.0.0-rc.10, cheerio@^1.0.0-rc.10:
   version "1.0.0-rc.10"
   resolved "https://registry.yarnpkg.com/cheerio/-/cheerio-1.0.0-rc.10.tgz#2ba3dcdfcc26e7956fc1f440e61d51c643379f3e"
   integrity sha512-g0J0q/O6mW8z5zxQ3A8E8J1hUgp4SMOvEoW/x84OwyHKe/Zccz83PVT4y5Crcr530FV6NgmKI1qvGTKVl9XXVw==
@@ -4336,6 +4324,18 @@ cheerio@^1.0.0-rc.10:
     parse5 "^6.0.1"
     parse5-htmlparser2-tree-adapter "^6.0.1"
     tslib "^2.2.0"
+
+cheerio@1.0.0-rc.2:
+  version "1.0.0-rc.2"
+  resolved "https://registry.yarnpkg.com/cheerio/-/cheerio-1.0.0-rc.2.tgz#4b9f53a81b27e4d5dac31c0ffd0cfa03cc6830db"
+  integrity sha1-S59TqBsn5NXawxwP/Qz6A8xoMNs=
+  dependencies:
+    css-select "~1.2.0"
+    dom-serializer "~0.1.0"
+    entities "~1.1.1"
+    htmlparser2 "^3.9.1"
+    lodash "^4.15.0"
+    parse5 "^3.0.1"
 
 chokidar@^2.0.0, chokidar@^2.0.2:
   version "2.1.8"


### PR DESCRIPTION
Previously unaccounted for, if an HTML string is empty (which is NOT a non-empty JavaScript string) it would still display.

PROD:
![Screenshot from 2022-11-14 09-42-19](https://user-images.githubusercontent.com/46794001/201703760-6ab7f703-a4ed-49fb-a7be-3637a4bee15b.png)

DEV:
![Screenshot from 2022-11-14 09-42-06](https://user-images.githubusercontent.com/46794001/201703781-ccae7bde-c689-45e1-bde9-adc42f649ec0.png)


PROD:
![Screenshot from 2022-11-14 09-39-20](https://user-images.githubusercontent.com/46794001/201703942-fd336269-284d-4f56-97f0-5e0ab05b2fff.png)

DEV:
![Screenshot from 2022-11-14 09-39-25](https://user-images.githubusercontent.com/46794001/201704007-4c1bc39e-fd1b-40e1-a920-d89bf8a96bd6.png)
