### PR TITLE
Add simple route/template for loading formstack forms

### DIFF
--- a/packages/global/routes/index.js
+++ b/packages/global/routes/index.js
@@ -13,6 +13,7 @@ const printContent = require('./print-content');
 const publicFiles = require('./public-files');
 const redirects = require('./redirects');
 const search = require('./search');
+const formstack = require('../templates/formstack');
 
 module.exports = (app, siteConfig) => {
   // HTML Sitemap
@@ -23,6 +24,12 @@ module.exports = (app, siteConfig) => {
 
   // Feed
   feed(app);
+
+  app.get('/formstack/:formId([a-z0-9-/_]+)', (req, res) => {
+    const { formId } = req.params;
+    // @todo: Look into API to get title & description to send to template as well
+    return res.marko(formstack, { formId });
+  });
 
   // magazine
   magazine(app);

--- a/packages/global/templates/formstack.marko
+++ b/packages/global/templates/formstack.marko
@@ -1,0 +1,37 @@
+import defaultValue from "@parameter1/base-cms-marko-core/utils/default-value";
+
+$ const { config, site, req } = out.global;
+$ const searchParams = new URLSearchParams({
+  ...req.query,
+  nomodernizr: 1,
+  no_style_strict: 1,
+}).toString();
+
+$ const { formId } = input;
+
+$ const scriptUrl = `https://IEN.formstack.com/forms/js.php/${formId}?${searchParams}`;
+$ const noscriptUrl = `https://IEN.formstack.com/forms/${formId}?${searchParams}`;
+
+$ const type = "page";
+$ const title = `${formId}` ;
+$ const description = "";
+
+<marko-web-default-page-layout type=type title=title description=description>
+  <@head>
+    <marko-web-gtm-default-context|{ context }| type=type>
+      <marko-web-gtm-push data=context />
+    </marko-web-gtm-default-context>
+  </@head>
+  <@page>
+    <marko-web-page-wrapper>
+      <@section>
+        <script type="text/javascript" src=scriptUrl></script>
+        <noscript>
+          <a href=noscriptUrl title="Online Form">
+            Online Form - ${formId}
+          </a>
+        </noscript>
+      </@section>
+    </marko-web-page-wrapper>
+  </@page>
+</marko-web-default-page-layout>

--- a/packages/global/templates/formstack.marko
+++ b/packages/global/templates/formstack.marko
@@ -12,11 +12,10 @@ $ const { formId } = input;
 $ const scriptUrl = `https://IEN.formstack.com/forms/js.php/${formId}?${searchParams}`;
 $ const noscriptUrl = `https://IEN.formstack.com/forms/${formId}?${searchParams}`;
 
-$ const type = "page";
-$ const title = `${formId}` ;
-$ const description = "";
+$ const type = "survey";
+$ const title = `Customer Survey - ${formId}` ;
 
-<marko-web-default-page-layout type=type title=title description=description>
+<marko-web-default-page-layout type=type title=title >
   <@head>
     <marko-web-gtm-default-context|{ context }| type=type>
       <marko-web-gtm-push data=context />


### PR DESCRIPTION
The new route will take /formstack/${lowercase-version-spaces-to-_-form-name}

**FormStack: shared path:** `https://ien.formstack.com/forms/making_the_culture_changes_that_assure_digital_transformation_success?utm_source=Industrial+Media&utm_medium=email&utm_campaign=02022023&utm_term=IMCD230201020&name-first=Jenna&name-last=Hulbert&email=jenna%40ien.com&phone_number=6087928007&nomodernizr=1&no_style_strict=1`

**Website Version:**
`https://www.ien.com/formstack/making_the_culture_changes_that_assure_digital_transformation_success?utm_source=Industrial+Media&utm_medium=email&utm_campaign=02022023&utm_term=IMCD230201020&name-first=Jenna&name-last=Hulbert&email=jenna%40ien.com&phone_number=6087928007&nomodernizr=1&no_style_strict=1`

**Example Form url parts**: `/making_the_culture_changes_that_assure_digital_transformation_success?utm_source=Industrial+Media&utm_medium=email&utm_campaign=02022023&utm_term=IMCD230201020&name-first=Jenna&name-last=Hulbert&email=jenna@ien.com&phone_number=6087928007`
<img width="781" alt="Screen Shot 2023-02-20 at 12 43 06 PM" src="https://user-images.githubusercontent.com/3845869/220180210-fe4d0c1c-6d2c-472a-aaad-306347cc935a.png">

