### PR TITLE
Wrap the global video player in sticky top class

### DIFF
--- a/packages/global/components/layouts/content/default.marko
+++ b/packages/global/components/layouts/content/default.marko
@@ -216,7 +216,9 @@ $ const shouldInjectAds = ["article", "video", "news", "podcast"].includes(type)
         </theme-latest-content-list-block>
         <!-- Only Fire when brightcove player is not included via content.embedCode -->
         <if(!content.embedCode)>
-          <global-video-player />
+          <div class="sticky-top" >
+            <global-video-player />
+          </div>
         </if>
       </div>
     </div>

--- a/packages/global/components/layouts/website-section/default.marko
+++ b/packages/global/components/layouts/website-section/default.marko
@@ -120,7 +120,9 @@ $ const promise = websiteSectionContentLoader(apollo, {
                 </div>
                 <div class="col-lg-4 page-rail">
                   <theme-latest-content-list-block nodes=standard.nodes title=rightRailHeader />
-                  <global-video-player />
+                  <div class="sticky-top" >
+                    <global-video-player />
+                  </div>
                 </div>
               </div>
             </@section>


### PR DESCRIPTION
This will force the video play to stick to the top of the right rail when a user scrolls up the page.

<img width="968" alt="Screen Shot 2023-04-27 at 8 25 25 PM" src="https://user-images.githubusercontent.com/3845869/235032355-51b2577b-7a97-4aa4-84e3-9bb27ae947ce.png">
