### PR TITLE
Remove read next block when primary section = Home

### DIFF
--- a/packages/global/components/layouts/content/default.marko
+++ b/packages/global/components/layouts/content/default.marko
@@ -18,7 +18,6 @@ $ const belowContentSections = getAsArray(input, "belowContentSections");
 
 $ const displayPrimaryImage = defaultValue(input.displayPrimaryImage, true);
 $ const displayPublishedDate = ["company", "contact", "whitepaper"].includes(type) ? false : true;
-$ const displayReadNext = showReadNextBlock && ["article"].includes(type);
 $ const displaySocialShare = ["contact"].includes(type) ? false : true;
 $ const displayComments = (site.get('identityX.comments.enabled') && !["contact"].includes(type)) ? true : false;
 $ const displayNewsletterSignup = ["contact"].includes(type) ? false : true;
@@ -195,6 +194,7 @@ $ const shouldInjectAds = ["article", "video", "news", "podcast"].includes(type)
               <theme-identity-x-comment-stream content=content />
             </if>
 
+            $ const displayReadNext = showReadNextBlock && ["article"].includes(type) && primarySection.alias !== 'home';
             <if(displayReadNext)>
               <theme-read-next-block
                 content-id=id


### PR DESCRIPTION
Open for discussion, essentially the `theme-read-next-block` uses an `all-published-content` query for the primary section of the content with the only exclusion being the content id you're looking at, this means for the home section (where everything lives for a site if unassigned anywhere else which will mostly be things like promotions, documents etc.) will display if it is the most recent item with that primary section (hence the Jenna dilemma), an alternative here would be allowing for passing in of `excludeContentTypes` to the `theme-read-next-block` which could remove things like pages, documents, etc. from that query and still present a read next block for other items with home as the primary section.

PROD:
![Screenshot from 2023-06-21 14-31-00](https://github.com/parameter1/industrial-media-websites/assets/46794001/cf981286-2c89-448e-a48e-e176385e90af)

DEV:
![Screenshot from 2023-06-21 14-31-05](https://github.com/parameter1/industrial-media-websites/assets/46794001/48e1060f-a9d5-40a6-a7df-e1d0e13ed625)

