### PR TITLE
Adjust 'Page' content type layout

### DIFF
--- a/packages/global/components/layouts/dynamic-page/index.marko
+++ b/packages/global/components/layouts/dynamic-page/index.marko
@@ -31,23 +31,37 @@ $ const { GAM } = out.global;
         </@section>
 
         <@section|{ blockName }|>
-          <div class="row">
-            <div class="col-lg-8">
-              <div class="content-page-body">
-                <theme-page-contents|{ blockName }| attrs={ "data-gallery-id": id }>
+          <if(input.rails)>
+            <div class="row">
+              <div class="col-lg-8">
+                <div class="content-page-body">
+                  <theme-page-contents|{ blockName }| attrs={ "data-gallery-id": id }>
 
-                  $ const bodyId = `content-body-${content.id}`;
-                  <marko-web-content-body block-name=blockName obj=content attrs={ id: bodyId } />
+                    $ const bodyId = `content-body-${content.id}`;
+                    <marko-web-content-body block-name=blockName obj=content attrs={ id: bodyId } />
 
-                </theme-page-contents>
+                  </theme-page-contents>
+                </div>
               </div>
-            </div>
-            <if(input.rails)>
               <div class="col-lg-4">
                 <${input.rails[0].renderBody} />
               </div>
-            </if>
-          </div>
+            </div>
+          </if>
+          <else>
+            <div class="row">
+              <div class="col-lg-12">
+                <div class="content-page-body">
+                  <theme-page-contents|{ blockName }| attrs={ "data-gallery-id": id }>
+
+                    $ const bodyId = `content-body-${content.id}`;
+                    <marko-web-content-body block-name=blockName obj=content attrs={ id: bodyId } />
+
+                  </theme-page-contents>
+                </div>
+              </div>
+            </div>
+          </else>
         </@section>
       </marko-web-page-wrapper>
     </marko-web-resolve-page>

--- a/packages/global/scss/core.scss
+++ b/packages/global/scss/core.scss
@@ -523,6 +523,7 @@ label {
 
 .page-contents {
   &__content-body {
+    width: 100%;
     li, ul {
       list-style-position: initial;
     }

--- a/packages/global/scss/core.scss
+++ b/packages/global/scss/core.scss
@@ -523,7 +523,6 @@ label {
 
 .page-contents {
   &__content-body {
-    width: 100%;
     li, ul {
       list-style-position: initial;
     }

--- a/packages/global/scss/core.scss
+++ b/packages/global/scss/core.scss
@@ -523,7 +523,7 @@ label {
 
 .page-contents {
   &__content-body {
-    ul {
+    li, ul {
       list-style-position: initial;
     }
   }


### PR DESCRIPTION
Text styling is now 'initial' if 2 lines:
<img width="1321" alt="Screen Shot 2023-08-02 at 3 31 52 PM" src="https://github.com/parameter1/industrial-media-websites/assets/64623209/ca711559-82c1-4144-bab8-5331a86c5363">

Updated 'page' layout:
<img width="1669" alt="Screen Shot 2023-08-02 at 3 32 10 PM" src="https://github.com/parameter1/industrial-media-websites/assets/64623209/71630132-509d-499f-bd75-5804abe69ac1">

If right rail... no change:
<img width="1678" alt="Screen Shot 2023-08-02 at 3 32 21 PM" src="https://github.com/parameter1/industrial-media-websites/assets/64623209/72724936-4658-4b02-a00e-2cd9f51fd214">
