### PR TITLE
Remove `idxNavItems` enablement, IEN

### DIFF
--- a/sites/ien.com/config/site.js
+++ b/sites/ien.com/config/site.js
@@ -18,9 +18,6 @@ module.exports = {
   omeda,
   omedaIdentityX,
   identityX,
-  idxNavItems: {
-    enable: true,
-  },
   magazine,
   nativeX,
   newsletter,


### PR DESCRIPTION
Appears a recent PR here: https://github.com/parameter1/industrial-media-websites/pull/359
Conflicted with how IEN had been setup to handle these via: https://github.com/parameter1/industrial-media-websites/pull/211

This should now function identically across all sites.
![Screenshot from 2023-12-19 11-41-42](https://github.com/parameter1/industrial-media-websites/assets/46794001/78511119-fd88-44c4-b620-a1ee3d6c69b1)
