### PR TITLE
Change section based nativeX ad slots to use 'Related Content' vs Default

### DIFF
--- a/packages/global/components/blocks/load-more/content-page.marko
+++ b/packages/global/components/blocks/load-more/content-page.marko
@@ -3,7 +3,7 @@ import defaultValue from "@parameter1/base-cms-marko-core/utils/default-value";
 
 $ const { GAM } = out.global;
 
-$ const { aliases } = input;
+$ const { aliases, name } = input;
 
 $ const content = getAsObject(input, "content");
 $ const section = getAsObject(input, "section");
@@ -79,5 +79,5 @@ $ const attrs = createAttrs();
     ...GAM.getAdUnit({ name: "infinite-interstitial", aliases })
     modifiers=["max-width-300", "margin-auto-x"]
   />
-  <@native-x indexes=[0] name="default" aliases=aliases />
+  <@native-x indexes=[0] name=name aliases=aliases />
 </global-latest-content-feed-load-more-block>

--- a/packages/global/components/layouts/content/wrapper.marko
+++ b/packages/global/components/layouts/content/wrapper.marko
@@ -75,7 +75,7 @@ $ const showOverlay = defaultValue(input.showOverlay, false);
                   >
                     <@content id=id type=type name=content.name />
                     <@section id=section.id name=section.name />
-                    <@native-x indexes=[0] name="default" aliases=aliases />
+                    <@native-x indexes=[0] name="related-content" aliases=aliases />
                   </global-content-page-load-more-block>
                 </div>
               </div>

--- a/packages/global/components/layouts/website-section/default.marko
+++ b/packages/global/components/layouts/website-section/default.marko
@@ -171,7 +171,7 @@ $ const promise = websiteSectionContentLoader(apollo, {
                           ...GAM.getAdUnit({ name: "infinite-interstitial", aliases })
                           modifiers=["max-width-300", "margin-auto-x"]
                         />
-                        <@native-x indexes=[0] name="default" aliases=aliases />
+                        <@native-x indexes=[0] name="related-content" aliases=aliases />
                       </global-latest-content-feed-load-more-block>
                     </div>
                   </div>

--- a/sites/designdevelopmenttoday.com/config/native-x.js
+++ b/sites/designdevelopmenttoday.com/config/native-x.js
@@ -30,9 +30,9 @@ config
   ])
   .setAliasPlacements('news', [
     { name: 'related-content', id: '6039b095e7c97d00013d9e71' },
-  ])
-  .setAliasPlacements('video', [
-    { name: 'related-content', id: '6039b0b2e7c97d00013d9fd6' },
   ]);
+  // .setAliasPlacements('video', [
+  //   { name: 'related-content', id: '6039b0b2e7c97d00013d9fd6' },
+  // ]);
 
 module.exports = config;

--- a/sites/designdevelopmenttoday.com/config/native-x.js
+++ b/sites/designdevelopmenttoday.com/config/native-x.js
@@ -28,11 +28,11 @@ config
   .setAliasPlacements('new-products', [
     { name: 'related-content', id: '6039b081e7c97d00013d9d7f' },
   ])
+  // .setAliasPlacements('video', [
+  //   { name: 'related-content', id: '6039b0b2e7c97d00013d9fd6' },
+  // ])
   .setAliasPlacements('news', [
     { name: 'related-content', id: '6039b095e7c97d00013d9e71' },
   ]);
-  // .setAliasPlacements('video', [
-  //   { name: 'related-content', id: '6039b0b2e7c97d00013d9fd6' },
-  // ]);
 
 module.exports = config;

--- a/sites/foodmanufacturing.com/config/native-x.js
+++ b/sites/foodmanufacturing.com/config/native-x.js
@@ -13,13 +13,13 @@ config
   .setAliasPlacements('safety', [
     { name: 'related-content', id: '603a9fd54a44ce000168ed68' },
   ])
-  .setAliasPlacements('recall-alerts', [
+  .setAliasPlacements('recalls-alerts', [
     { name: 'related-content', id: '603a9fb70057fb0001ef4c87' },
   ])
   .setAliasPlacements('packaging', [
     { name: 'related-content', id: '603a9f770057fb0001ef49e1' },
   ])
-  .setAliasPlacements('new-products', [
+  .setAliasPlacements('products', [
     { name: 'related-content', id: '603a9f904a44ce000168eaf7' },
   ])
   .setAliasPlacements('labor', [

--- a/sites/inddist.com/config/native-x.js
+++ b/sites/inddist.com/config/native-x.js
@@ -33,6 +33,12 @@ config
   ])
   .setAliasPlacements('big-50', [
     { name: 'related-content', id: '603aa4cc0057fb0001ef7542' },
+  ])
+  .setAliasPlacements('new-products', [
+    { name: 'related-content', id: '65bbce623072e90001db3644' },
   ]);
+  // .setAliasPlacements('5-minutes-with-id', [
+  //   { name: 'related-content', id: '65bbcee83072e90001db369a' },
+  // ])
 
 module.exports = config;

--- a/sites/inddist.com/config/native-x.js
+++ b/sites/inddist.com/config/native-x.js
@@ -34,11 +34,11 @@ config
   .setAliasPlacements('big-50', [
     { name: 'related-content', id: '603aa4cc0057fb0001ef7542' },
   ])
-  .setAliasPlacements('new-products', [
-    { name: 'related-content', id: '65bbce623072e90001db3644' },
-  ]);
   // .setAliasPlacements('5-minutes-with-id', [
   //   { name: 'related-content', id: '65bbcee83072e90001db369a' },
   // ])
+  .setAliasPlacements('new-products', [
+    { name: 'related-content', id: '65bbce623072e90001db3644' },
+  ]);
 
 module.exports = config;

--- a/sites/manufacturing.net/config/native-x.js
+++ b/sites/manufacturing.net/config/native-x.js
@@ -30,6 +30,9 @@ config
   ])
   .setAliasPlacements('aerospace', [
     { name: 'related-content', id: '603aa3dd0057fb0001ef6f4a' },
+  ])
+  .setAliasPlacements('artificial-intelligence', [
+    { name: 'related-content', id: '65bbd7b23072e90001db3dec' },
   ]);
 
 module.exports = config;


### PR DESCRIPTION
No NativeX ad for this section-ROS ad is running:
<img width="1334" alt="Screen Shot 2024-02-01 at 11 20 21 AM" src="https://github.com/parameter1/industrial-media-websites/assets/64623209/b3b657c8-2c92-4acc-8702-549e8647c5f1">
NativeX ad for 'Supply Chain'-ROS ad is NOT running:
<img width="1322" alt="Screen Shot 2024-02-01 at 11 21 08 AM" src="https://github.com/parameter1/industrial-media-websites/assets/64623209/e8c9e7c9-3a4c-4e0c-be8d-13f5a2dbf13c">
PROD:
<img width="1530" alt="Screen Shot 2024-02-01 at 11 21 32 AM" src="https://github.com/parameter1/industrial-media-websites/assets/64623209/a4b06cfe-0dae-4ac5-a28f-69e5e693b104">
DEV:
<img width="1681" alt="Screen Shot 2024-02-01 at 11 21 45 AM" src="https://github.com/parameter1/industrial-media-websites/assets/64623209/cfc6d6d2-da17-40ec-8eb2-abe34cb8d70e">
