### PR TITLE
Change section based nativeX ad slots to use 'Related Content' vs Default

### DIFF
--- a/packages/global/components/blocks/load-more/content-page.marko
+++ b/packages/global/components/blocks/load-more/content-page.marko
@@ -6,7 +6,7 @@ $ const { GAM } = out.global;
 $ const { aliases } = input;
 
 $ const nativeX = getAsObject(input, "nativeX");
-$ const nativeXPlacementName = "nativeX.name" || "default";
+$ const nativeXPlacementName = nativeX.name || "default";
 
 $ const content = getAsObject(input, "content");
 $ const section = getAsObject(input, "section");

--- a/packages/global/components/blocks/load-more/content-page.marko
+++ b/packages/global/components/blocks/load-more/content-page.marko
@@ -5,6 +5,9 @@ $ const { GAM } = out.global;
 
 $ const { aliases } = input;
 
+$ const nativeX = getAsObject(input, "nativeX");
+$ const nativeXPlacementName = "nativeX.name" || "default";
+
 $ const content = getAsObject(input, "content");
 $ const section = getAsObject(input, "section");
 
@@ -79,5 +82,5 @@ $ const attrs = createAttrs();
     ...GAM.getAdUnit({ name: "infinite-interstitial", aliases })
     modifiers=["max-width-300", "margin-auto-x"]
   />
-  <@native-x indexes=[0] name="default" aliases=aliases />
+  <@native-x indexes=[0] name=nativeXPlacementName aliases=aliases />
 </global-latest-content-feed-load-more-block>

--- a/packages/global/components/layouts/content/wrapper.marko
+++ b/packages/global/components/layouts/content/wrapper.marko
@@ -55,9 +55,10 @@ $ const showOverlay = defaultValue(input.showOverlay, false);
 
         <marko-web-resolve-page|{ data: content, resolved }| node=pageNode>
           $ const section = content.primarySection;
+          $ const aliases = hierarchyAliases(content.primarySection);
           <marko-web-page-wrapper>
             <if(displayAds)>
-              <@section|{ aliases }| modifiers=["first-sm"]>
+              <@section modifiers=["first-sm"]>
                 <theme-gam-define-display-ad
                   name="billboard"
                   position="content_page"
@@ -66,7 +67,7 @@ $ const showOverlay = defaultValue(input.showOverlay, false);
                 />
               </@section>
             </if>
-            <@section|{ aliases }|>
+            <@section>
               <div class="row">
                 <div class="col-lg-12 infinite-scroll-target">
                   <global-content-page-load-more-block

--- a/packages/global/components/layouts/content/wrapper.marko
+++ b/packages/global/components/layouts/content/wrapper.marko
@@ -75,7 +75,7 @@ $ const showOverlay = defaultValue(input.showOverlay, false);
                   >
                     <@content id=id type=type name=content.name />
                     <@section id=section.id name=section.name />
-                    <@native-x indexes=[0] name="default" aliases=aliases />
+                    <@native-x indexes=[0] name="related-content" aliases=aliases />
                   </global-content-page-load-more-block>
                 </div>
               </div>

--- a/packages/global/components/layouts/website-section/default.marko
+++ b/packages/global/components/layouts/website-section/default.marko
@@ -171,7 +171,7 @@ $ const promise = websiteSectionContentLoader(apollo, {
                           ...GAM.getAdUnit({ name: "infinite-interstitial", aliases })
                           modifiers=["max-width-300", "margin-auto-x"]
                         />
-                        <@native-x indexes=[0] name="default" aliases=aliases />
+                        <@native-x indexes=[0] name="related-content" aliases=aliases />
                       </global-latest-content-feed-load-more-block>
                     </div>
                   </div>

--- a/sites/designdevelopmenttoday.com/config/native-x.js
+++ b/sites/designdevelopmenttoday.com/config/native-x.js
@@ -30,9 +30,6 @@ config
   ])
   .setAliasPlacements('news', [
     { name: 'related-content', id: '6039b095e7c97d00013d9e71' },
-  ])
-  .setAliasPlacements('video', [
-    { name: 'related-content', id: '6039b0b2e7c97d00013d9fd6' },
   ]);
 
 module.exports = config;

--- a/sites/foodmanufacturing.com/config/native-x.js
+++ b/sites/foodmanufacturing.com/config/native-x.js
@@ -13,13 +13,13 @@ config
   .setAliasPlacements('safety', [
     { name: 'related-content', id: '603a9fd54a44ce000168ed68' },
   ])
-  .setAliasPlacements('recall-alerts', [
+  .setAliasPlacements('recalls-alerts', [
     { name: 'related-content', id: '603a9fb70057fb0001ef4c87' },
   ])
   .setAliasPlacements('packaging', [
     { name: 'related-content', id: '603a9f770057fb0001ef49e1' },
   ])
-  .setAliasPlacements('new-products', [
+  .setAliasPlacements('products', [
     { name: 'related-content', id: '603a9f904a44ce000168eaf7' },
   ])
   .setAliasPlacements('labor', [

--- a/sites/inddist.com/config/native-x.js
+++ b/sites/inddist.com/config/native-x.js
@@ -33,6 +33,9 @@ config
   ])
   .setAliasPlacements('big-50', [
     { name: 'related-content', id: '603aa4cc0057fb0001ef7542' },
+  ])
+  .setAliasPlacements('new-products', [
+    { name: 'related-content', id: '65bbce623072e90001db3644' },
   ]);
 
 module.exports = config;

--- a/sites/manufacturing.net/config/native-x.js
+++ b/sites/manufacturing.net/config/native-x.js
@@ -30,6 +30,9 @@ config
   ])
   .setAliasPlacements('aerospace', [
     { name: 'related-content', id: '603aa3dd0057fb0001ef6f4a' },
+  ])
+  .setAliasPlacements('artificial-intelligence', [
+    { name: 'related-content', id: '65bbd7b23072e90001db3dec' }
   ]);
 
 module.exports = config;

--- a/sites/manufacturing.net/config/native-x.js
+++ b/sites/manufacturing.net/config/native-x.js
@@ -32,7 +32,7 @@ config
     { name: 'related-content', id: '603aa3dd0057fb0001ef6f4a' },
   ])
   .setAliasPlacements('artificial-intelligence', [
-    { name: 'related-content', id: '65bbd7b23072e90001db3dec' }
+    { name: 'related-content', id: '65bbd7b23072e90001db3dec' },
   ]);
 
 module.exports = config;


### PR DESCRIPTION
PROD:
<img width="1226" alt="Screen Shot 2024-02-05 at 11 21 33 AM" src="https://github.com/parameter1/industrial-media-websites/assets/64623209/2e4e0bc6-f41f-434d-9983-4eb48725ed6c">
<img width="1286" alt="Screen Shot 2024-02-05 at 11 21 59 AM" src="https://github.com/parameter1/industrial-media-websites/assets/64623209/754bb215-110d-467f-a703-7eb5590b3d5a">
<img width="1312" alt="Screen Shot 2024-02-05 at 11 21 45 AM" src="https://github.com/parameter1/industrial-media-websites/assets/64623209/c06167d1-f59a-4261-84fe-e4987dd2733c">

DEV:
<img width="1184" alt="Screen Shot 2024-02-05 at 11 21 01 AM" src="https://github.com/parameter1/industrial-media-websites/assets/64623209/eb0a282f-55ee-42b8-9033-d159da0c998f">
<img width="1188" alt="Screen Shot 2024-02-05 at 11 21 17 AM" src="https://github.com/parameter1/industrial-media-websites/assets/64623209/b741a023-68e0-4317-a3ca-9d79d3ea56bc">
<img width="1239" alt="Screen Shot 2024-02-05 at 11 21 51 AM" src="https://github.com/parameter1/industrial-media-websites/assets/64623209/9c226163-1c45-4401-b04d-183be114984c">

