### PR TITLE
Add videoId || videoPlaylistId brighrtcove fallback logic

### DIFF
--- a/packages/global/browser/brightcove-gam-player.vue
+++ b/packages/global/browser/brightcove-gam-player.vue
@@ -87,15 +87,17 @@ export default {
   methods: {
     async listener(event) {
       const payload = parseJson(event.data);
-      const videoIdKeys = ['bcPlaylistId', 'bclVideoId'];
-      payload.hasVideoId = videoIdKeys.some((k) => payload[k]);
-      const brightcoveKeys = ['bcAccountId', 'bcPlayerId', 'hasVideoId'];
-      if (brightcoveKeys.every((j) => payload[j])) {
+      // you must have a accountId, playerID & (videoId || playlistId)
+      if (
+        ['bcAccountId', 'bcPlayerId'].every((j) => payload[j])
+        && ['bcPlaylistId', 'bclVideoId'].some((k) => payload[k])
+      ) {
         try {
           const { ref } = await brightcovePlayerLoader({
             accountId: payload.bcAccountId,
             playerId: payload.bcPlayerId,
             embedId: payload.embedId || 'default',
+            // use videoId over playlistId, should be more specific
             videoId: payload.bcVideoId,
             ...(!payload.bcVideoId && { playlistId: payload.bcPlaylistId }),
             refNode: this.$el,

--- a/packages/global/browser/brightcove-gam-player.vue
+++ b/packages/global/browser/brightcove-gam-player.vue
@@ -87,7 +87,9 @@ export default {
   methods: {
     async listener(event) {
       const payload = parseJson(event.data);
-      const brightcoveKeys = ['bcAccountId', 'bcPlayerId', 'bcPlaylistId'];
+      const videoIdKeys = ['bcPlaylistId', 'bclVideoId'];
+      payload.hasVideoId = videoIdKeys.some((k) => payload[k]);
+      const brightcoveKeys = ['bcAccountId', 'bcPlayerId', 'hasVideoId'];
       if (brightcoveKeys.every((j) => payload[j])) {
         try {
           const { ref } = await brightcovePlayerLoader({
@@ -95,7 +97,7 @@ export default {
             playerId: payload.bcPlayerId,
             embedId: payload.embedId || 'default',
             videoId: payload.bcVideoId,
-            playlistId: payload.bcPlaylistId,
+            ...(!payload.bcVideoId && { playlistId: payload.bcPlaylistId }),
             refNode: this.$el,
             options: {
               autoplay: false,


### PR DESCRIPTION
Check to see that at least one of  bcVideoId || bcPlaylistId are set and use videoId with a fallback of playlistId

When both are set you will get a data conflict error when using the brightcovePlayerLoader() call.  

