### PR TITLE
Append gam tracker for impression tracking of brightcove ad

### DIFF
--- a/packages/global/browser/brightcove-gam-player.vue
+++ b/packages/global/browser/brightcove-gam-player.vue
@@ -127,6 +127,12 @@ export default {
           this.player.pause();
           this.open = true;
           this.setAutoPlayObserver();
+          // append trasnparent tracking pixel
+          const tracker = document.createElement('img');
+          tracker.setAttribute('src', `${payload.VIEW_URL_UNESC}`);
+          tracker.style.display = 'none';
+          document.getElementById('brightcove-gam-player').appendChild(tracker);
+
           document.getElementById('brightcove-gam-player-button').classList.add('active');
         } catch (e) {
           const { error } = console;

--- a/packages/global/browser/brightcove-gam-player.vue
+++ b/packages/global/browser/brightcove-gam-player.vue
@@ -129,7 +129,7 @@ export default {
           this.setAutoPlayObserver();
           // append trasnparent tracking pixel
           const tracker = document.createElement('img');
-          tracker.setAttribute('src', `${payload.VIEW_URL_UNESC}`);
+          tracker.setAttribute('src', payload.VIEW_URL_UNESC);
           tracker.style.display = 'none';
           document.getElementById('brightcove-gam-player').appendChild(tracker);
 


### PR DESCRIPTION
Add the appending and rendering of the impression tracker for gam

per https://support.google.com/admanager/answer/6088046?hl=en  It will now appending the required impression tracking <img /> 

<img width="1000" alt="Screenshot 2024-02-09 at 12 27 03 PM" src="https://github.com/parameter1/industrial-media-websites/assets/3845869/f2f8b637-727a-45e2-ab96-4551c64a931d">
