### PR TITLE
Add ‘/‘ before gen-z in navigation

### DIFF
--- a/sites/manufacturing.net/config/navigation.js
+++ b/sites/manufacturing.net/config/navigation.js
@@ -6,7 +6,7 @@ const topics = sortNavItems([
   { href: '/artificial-intelligence', label: 'AI' },
   { href: '/automotive', label: 'Automotive' },
   { href: '/energy', label: 'Energy' },
-  { href: 'gen-z-in-manufacturing-podcast', label: 'Gen Z' },
+  { href: '/gen-z-in-manufacturing-podcast', label: 'Gen Z' },
   { href: '/industry40', label: 'Industry 4.0' },
   { href: '/cybersecurity', label: 'Cybersecurity' },
   { href: '/operations', label: 'Operations' },


### PR DESCRIPTION
<img width="1403" alt="Screenshot 2024-03-20 at 8 49 58 AM" src="https://github.com/parameter1/industrial-media-websites/assets/64623209/fddb7413-f3d7-48fb-a207-c0a547af85ac">
