### PR TITLE
Add check for nativeX img vs standard node img

### DIFF
--- a/packages/global/components/flows/content/card-deck.marko
+++ b/packages/global/components/flows/content/card-deck.marko
@@ -29,7 +29,14 @@ $ const adName = "load-more";
         attrs=getAsObject(node, "attributes.container")
         link-attrs=getAsObject(node, "attributes.link")
       >
-        <@image fluid=true width=330 ar="3:2" />
+        <!-- If native x force primary image display to be fit: fill and fill with white with no crop. -->
+        <if(node.primaryImage && node.primaryImage.src.includes('https://native-x.imgix.net/'))>
+          <@image fluid=false width=330 ar="3:2" options={ fit: "fill", "fill-color": "#fff",  crop : "none" }/>
+        </if>
+        <else>
+          <@image fluid=true width=330 ar="3:2" />
+        </else>
+
       </theme-content-node>
     </@slot>
     <if(adIndices !== null)>


### PR DESCRIPTION
If native x do not for crop but rather display in a fit fill fashion.

Basically preventing croping of native x image and rather forcing the fit fill with a white fill color and no crop. 

<img width="1117" alt="Screenshot 2024-05-09 at 10 18 37 AM" src="https://github.com/parameter1/industrial-media-websites/assets/3845869/ca64ca4f-c356-4db0-8cba-4c7933b4fda5">
