### PR TITLE
Add GAM keyValue targeting to content landing pages

### DIFF
--- a/packages/global/components/gam-content-targeting.marko
+++ b/packages/global/components/gam-content-targeting.marko
@@ -1,0 +1,28 @@
+import { getAsObject, get, getAsArray } from "@parameter1/base-cms-object-path";
+import gamContentTags from "../utils/gam-content-tags";
+
+$ const content = getAsObject(input, "obj");
+
+$ const { id, type } = content;
+$ const companyIds = getAsArray(content, "companies.edges").map(({ node }) => node.id);
+$ const companyId = get(content, "company.id");
+$ const tags = gamContentTags(content);
+$ if (companyId) companyIds.unshift(companyId);
+
+$ const labels = getAsArray(content, "labels");
+$ const sponsored = labels.includes("Sponsored");
+<!-- If there are no Channels apply the General Fallback value -->
+$ const keyValues = {
+  cont_id: id,
+  cont_type: type,
+  ...(companyIds.length && {
+    companies: companyIds.join("|"),
+    Company: companyIds.shift(),
+  }),
+  section: get(content, "primarySection.alias"),
+  ...(tags && { tag_list: tags }),
+  ...(sponsored && { sponsored: "yes" }),
+};
+$ console.log('hitting: ', keyValues)
+<marko-web-gam-targeting key-values=keyValues />
+<${input.renderBody} />

--- a/packages/global/components/layouts/content/wrapper.marko
+++ b/packages/global/components/layouts/content/wrapper.marko
@@ -11,11 +11,13 @@ $ const showOverlay = defaultValue(input.showOverlay, false);
 
 <theme-content-page id=id type=type>
   <@head>
-    <marko-web-gtm-content-context|{ context }| id=id>
-      <marko-web-gtm-push data=context />
-    </marko-web-gtm-content-context>
     <marko-web-resolve-page|{ data: content }| node=pageNode>
       <marko-web-p1-events-track-content node=content />
+      <global-gam-content-targeting obj=content>
+        <marko-web-gtm-content-context|{ context }| id=id>
+          <marko-web-gtm-push data=context />
+        </marko-web-gtm-content-context>
+      </global-gam-content-targeting>
     </marko-web-resolve-page>
   </@head>
   <@above-container>

--- a/packages/global/components/marko.json
+++ b/packages/global/components/marko.json
@@ -9,6 +9,9 @@
     "template": "./fixed-ad-bottom.marko",
     "@aliases": "array"
   },
+  "<global-gam-content-targeting>": {
+    "template": "./gam-content-targeting.marko"
+  },
   "<global-document>": {
     "template": "./document.marko",
     "<head>": {},

--- a/packages/global/utils/gam-content-tags.js
+++ b/packages/global/utils/gam-content-tags.js
@@ -1,0 +1,8 @@
+const { getAsArray } = require('@parameter1/base-cms-object-path');
+
+const gamifyTagName = (name) => name
+  .replace(/[^/" ".&a-zA-Z0-9_-]/g, '')
+  .toLowerCase();
+
+module.exports = (content) => getAsArray(content, 'tags.edges')
+  .map(({ node }) => gamifyTagName(node.name));


### PR DESCRIPTION
This will add things like cont_id, content_type & Company


```

{
  cont_id: id,
  cont_type: type,
  ...(companyIds.length && {
    companies: companyIds.join("|"),
    Company: companyIds.shift(),
  }),
  section: get(content, "primarySection.alias"),
  ...(tags && { tag_list: tags }),
  ...(sponsored && { sponsored: "yes" }),
}

```

<img width="1642" alt="Screenshot 2024-05-24 at 9 26 17 AM" src="https://github.com/parameter1/industrial-media-websites/assets/3845869/7b3e34e9-d806-40e2-b5ff-a82faf2d7724">
<img width="969" alt="Screenshot 2024-05-24 at 9 32 44 AM" src="https://github.com/parameter1/industrial-media-websites/assets/3845869/06162a95-3abe-4cea-a823-229d06c1b571">

