### PR TITLE
Utilize button to show Transcript when clicked

### DIFF
--- a/packages/global/components/layouts/content/default.marko
+++ b/packages/global/components/layouts/content/default.marko
@@ -105,14 +105,14 @@ $ const shouldInjectAds = displayAds && ["article", "video", "news", "podcast"].
                 />
               </if>
               <if(content.transcript)>
-                <button
+                <a
+                  href=`#transcript-${id}`
                   class="btn btn-transcript mt-block mb-2"
-                  onclick=`
-                    document.getElementById("transcript-${id}").removeAttribute("style");
-                    window.location.hash = "transcript-${id}";
-                `>
+                  title="Transcript"
+                  onclick=`document.getElementById("transcript-${id}").removeAttribute("style");`
+                >
                   <marko-web-icon name="file" modifiers=["lg"] /> Transcript
-                </button>
+                </a>
               </if>
             </if>
             <else-if(type === "media-gallery")>

--- a/packages/global/components/layouts/content/default.marko
+++ b/packages/global/components/layouts/content/default.marko
@@ -105,9 +105,14 @@ $ const shouldInjectAds = displayAds && ["article", "video", "news", "podcast"].
                 />
               </if>
               <if(content.transcript)>
-                <marko-web-link href=`#transcript-${id}` class="btn btn-transcript mt-block mb-2" title="Transcript">
+                <button
+                  class="btn btn-transcript mt-block mb-2"
+                  onclick=`
+                    document.getElementById("transcript-${id}").removeAttribute("style");
+                    window.location.hash = "transcript-${id}";
+                `>
                   <marko-web-icon name="file" modifiers=["lg"] /> Transcript
-                </marko-web-link>
+                </button>
               </if>
             </if>
             <else-if(type === "media-gallery")>
@@ -166,7 +171,7 @@ $ const shouldInjectAds = displayAds && ["article", "video", "news", "podcast"].
                   preventHTMLInjection=!shouldInjectAds
                 />
                 <if(content.transcript)>
-                  <div id=`transcript-${id}` class="page-contents__content-transcript">
+                  <div id=`transcript-${id}` class="page-contents__content-transcript" style="display: none;">
                     <marko-web-element block-name="page-contents" name="content-transcript-title">
                       <marko-web-icon name="file" modifiers=["lg"] /> Transcript
                     </marko-web-element>


### PR DESCRIPTION
Content ID Example: 22909409

On Page Load:
![Screenshot from 2024-08-21 10-48-05](https://github.com/user-attachments/assets/b04a03dc-a914-4f0d-bf93-d0df23cd78e3)

When Button is clicked (where you're jumped to), functions as it does now:
![Screenshot from 2024-08-21 10-48-44](https://github.com/user-attachments/assets/d5448a40-600f-4f7b-981a-f01d358e118e)
