### PR TITLE
Add ‘Since (year)’ to secondary nav

### DIFF
--- a/sites/foodmanufacturing.com/config/navigation.js
+++ b/sites/foodmanufacturing.com/config/navigation.js
@@ -15,6 +15,7 @@ const topics = sortNavItems([
 ]);
 
 const secondary = [
+  { href: '/page/fm-about-us', label: 'Since 1987' },
   { href: '/video', label: 'Video' },
   { href: 'https://www.foodmanufacturing.com/formstack/advertise_with_im_foodmfg', label: 'Advertise', target: '_blank' },
   { href: 'https://industrialmedia.dragonforms.com/loading.do?omedasite=fm_signup', label: 'Newsletter Signup', target: '_blank' },

--- a/sites/ien.com/config/navigation.js
+++ b/sites/ien.com/config/navigation.js
@@ -17,6 +17,7 @@ const topics = sortNavItems([
 ]);
 
 const secondary = [
+  { href: '/page/about-us', label: 'Since 1933' },
   { href: '/video', label: 'Video' },
   { href: 'https://www.ien.com/formstack/advertise_with_im_ien', label: 'Advertise', target: '_blank' },
   { href: 'https://industrialmedia.dragonforms.com/loading.do?omedasite=ien_signup', label: 'Newsletter Signup', target: '_blank' },

--- a/sites/impomag.com/config/navigation.js
+++ b/sites/impomag.com/config/navigation.js
@@ -12,6 +12,7 @@ const topics = sortNavItems([
 ]);
 
 const secondary = [
+  { href: '/page/impo-about-us', label: 'Since 1939' },
   { href: '/video', label: 'Video' },
   { href: 'https://www.impomag.com/formstack/advertise_with_im_impo', label: 'Advertise', target: '_blank' },
   { href: 'https://industrialmedia.dragonforms.com/loading.do?omedasite=impo_signup', label: 'Newsletter Signup', target: '_blank' },

--- a/sites/inddist.com/config/navigation.js
+++ b/sites/inddist.com/config/navigation.js
@@ -14,6 +14,7 @@ const topics = [
 ];
 
 const secondary = [
+  { href: '/page/id-about-us', label: 'Since 1911' },
   { href: '/video', label: 'Video' },
   { href: 'https://www.inddist.com/formstack/advertise_with_im_id', label: 'Advertise', target: '_blank' },
   { href: 'https://industrialmedia.dragonforms.com/loading.do?omedasite=id_signup', label: 'Newsletter Signup', target: '_blank' },

--- a/sites/manufacturing.net/config/navigation.js
+++ b/sites/manufacturing.net/config/navigation.js
@@ -15,6 +15,7 @@ const topics = sortNavItems([
 ]);
 
 const secondary = [
+  { href: '/page/mnet-about-us', label: 'Since 1998' },
   { href: '/video', label: 'Video' },
   { href: 'https://www.manufacturing.net/formstack/advertise_with_im_mnet', label: 'Advertise', target: '_blank' },
   { href: 'https://industrialmedia.dragonforms.com/loading.do?omedasite=mnet_signup', label: 'Newsletter Signup', target: '_blank' },


### PR DESCRIPTION
<img width="1215" alt="Screenshot 2024-09-19 at 10 05 46 AM" src="https://github.com/user-attachments/assets/896c96ca-0a80-4b3d-93ed-676a097d8415">
<img width="1312" alt="Screenshot 2024-09-19 at 10 07 27 AM" src="https://github.com/user-attachments/assets/0a23a993-6c2d-467f-9e67-e3138f21ad02">
<img width="1278" alt="Screenshot 2024-09-19 at 10 10 25 AM" src="https://github.com/user-attachments/assets/cdd13752-1a84-4d29-b6d9-74693905b5a2">
<img width="1490" alt="Screenshot 2024-09-19 at 10 10 36 AM" src="https://github.com/user-attachments/assets/9ee0d282-738c-4f26-83d2-69be24623c4c">
<img width="1260" alt="Screenshot 2024-09-19 at 10 12 27 AM" src="https://github.com/user-attachments/assets/b7116d5b-1ab8-415f-828d-0dac5ba821bd">
